### PR TITLE
feat(core): pass NetworkedVar instance into custom permission callbacks

### DIFF
--- a/MLAPI-Editor/NetworkedBehaviourEditor.cs
+++ b/MLAPI-Editor/NetworkedBehaviourEditor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using MLAPI;
@@ -57,7 +57,7 @@ namespace UnityEditor
             if (value == null)
             {
                 Type fieldType = networkedVarFields[networkedVarNames[index]].FieldType;
-                INetworkedVar var = (INetworkedVar) Activator.CreateInstance(fieldType, true);
+                NetworkedVarBase var = (NetworkedVarBase) Activator.CreateInstance(fieldType, true);
                 networkedVarFields[networkedVarNames[index]].SetValue(target, var);
             }
             

--- a/MLAPI/Core/NetworkedBehaviour.cs
+++ b/MLAPI/Core/NetworkedBehaviour.cs
@@ -223,7 +223,7 @@ namespace MLAPI
 
         private readonly List<HashSet<int>> channelMappedNetworkedVarIndexes = new List<HashSet<int>>();
         private readonly List<string> channelsForNetworkedVarGroups = new List<string>();
-        internal readonly List<INetworkedVar> networkedVarFields = new List<INetworkedVar>();
+        internal readonly List<NetworkedVarBase> networkedVarFields = new List<NetworkedVarBase>();
 
         private static readonly Dictionary<Type, FieldInfo[]> fieldTypes = new Dictionary<Type, FieldInfo[]>();
 
@@ -297,17 +297,17 @@ namespace MLAPI
                     }
                 }
 
-                if (fieldType.HasInterface(typeof(INetworkedVar)))
+                if (fieldType.HasAncestorType(typeof(NetworkedVarBase)))
                 {
-                    INetworkedVar instance = (INetworkedVar)sortedFields[i].GetValue(this);
+                    NetworkedVarBase instance = (NetworkedVarBase)sortedFields[i].GetValue(this);
 
                     if (instance == null)
                     {
-                        instance = (INetworkedVar)Activator.CreateInstance(fieldType, true);
+                        instance = (NetworkedVarBase)Activator.CreateInstance(fieldType, true);
                         sortedFields[i].SetValue(this, instance);
                     }
 
-                    instance.SetNetworkedBehaviour(this);
+                    instance.networkedBehaviour = this;
                     networkedVarFields.Add(instance);
                 }
             }
@@ -647,7 +647,7 @@ namespace MLAPI
             }
         }
 
-        internal static void HandleNetworkedVarDeltas(List<INetworkedVar> networkedVarList, Stream stream, ulong clientId, NetworkedBehaviour logInstance)
+        internal static void HandleNetworkedVarDeltas(List<NetworkedVarBase> networkedVarList, Stream stream, ulong clientId, NetworkedBehaviour logInstance)
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
@@ -714,7 +714,7 @@ namespace MLAPI
             }
         }
 
-        internal static void HandleNetworkedVarUpdate(List<INetworkedVar> networkedVarList, Stream stream, ulong clientId, NetworkedBehaviour logInstance)
+        internal static void HandleNetworkedVarUpdate(List<NetworkedVarBase> networkedVarList, Stream stream, ulong clientId, NetworkedBehaviour logInstance)
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
@@ -866,7 +866,7 @@ namespace MLAPI
             }
         }
 
-        internal static void WriteNetworkedVarData(List<INetworkedVar> networkedVarList, Stream stream, ulong clientId)
+        internal static void WriteNetworkedVarData(List<NetworkedVarBase> networkedVarList, Stream stream, ulong clientId)
         {
             if (networkedVarList.Count == 0)
                 return;
@@ -911,7 +911,7 @@ namespace MLAPI
             }
         }
 
-        internal static void SetNetworkedVarData(List<INetworkedVar> networkedVarList, Stream stream)
+        internal static void SetNetworkedVarData(List<NetworkedVarBase> networkedVarList, Stream stream)
         {
             if (networkedVarList.Count == 0)
                 return;

--- a/MLAPI/NetworkedVar/Collections/NetworkedDictionary.cs
+++ b/MLAPI/NetworkedVar/Collections/NetworkedDictionary.cs
@@ -339,7 +339,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.WritePermissionCallback == null) return false;
-                    return Settings.WritePermissionCallback(clientId);
+                    return Settings.WritePermissionCallback(clientId, networkedBehaviour);
                 }
             }
 
@@ -360,7 +360,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.ReadPermissionCallback == null) return false;
-                    return Settings.ReadPermissionCallback(clientId);
+                    return Settings.ReadPermissionCallback(clientId, networkedBehaviour);
                 }
             }
 

--- a/MLAPI/NetworkedVar/Collections/NetworkedList.cs
+++ b/MLAPI/NetworkedVar/Collections/NetworkedList.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using MLAPI.Serialization;
@@ -111,7 +111,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.WritePermissionCallback == null) return false;
-                    return Settings.WritePermissionCallback(clientId);
+                    return Settings.WritePermissionCallback(clientId, networkedBehaviour);
                 }
             }
 
@@ -132,7 +132,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.ReadPermissionCallback == null) return false;
-                    return Settings.ReadPermissionCallback(clientId);
+                    return Settings.ReadPermissionCallback(clientId, networkedBehaviour);
                 }
             }
 

--- a/MLAPI/NetworkedVar/Collections/NetworkedList.cs
+++ b/MLAPI/NetworkedVar/Collections/NetworkedList.cs
@@ -10,11 +10,10 @@ namespace MLAPI.NetworkedVar.Collections
     /// Event based networkedVar container for syncing Lists
     /// </summary>
     /// <typeparam name="T">The type for the list</typeparam>
-    public class NetworkedList<T> : IList<T>, INetworkedVar
+    public class NetworkedList<T> : NetworkedVarBase, IList<T>
     {
         private readonly IList<T> list = new List<T>();
         private readonly List<NetworkedListEvent<T>> dirtyEvents = new List<NetworkedListEvent<T>>();
-        private NetworkedBehaviour networkedBehaviour;
 
         /// <summary>
         /// Gets the last time the variable was synced
@@ -75,14 +74,14 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void ResetDirty()
+        public override void ResetDirty()
         {
             dirtyEvents.Clear();
             LastSyncedTime = NetworkingManager.Singleton.NetworkTime;
         }
 
         /// <inheritdoc />
-        public bool IsDirty()
+        public override bool IsDirty()
         {
             if (dirtyEvents.Count == 0) return false;
             if (Settings.SendTickrate == 0) return true;
@@ -92,13 +91,13 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public string GetChannel()
+        public override string GetChannel()
         {
             return Settings.SendChannel;
         }
 
         /// <inheritdoc />
-        public bool CanClientWrite(ulong clientId)
+        public override bool CanClientWrite(ulong clientId)
         {
             switch (Settings.WritePermission)
             {
@@ -111,7 +110,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.WritePermissionCallback == null) return false;
-                    return Settings.WritePermissionCallback(clientId, networkedBehaviour);
+                    return Settings.WritePermissionCallback(clientId, this);
                 }
             }
 
@@ -119,7 +118,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public bool CanClientRead(ulong clientId)
+        public override bool CanClientRead(ulong clientId)
         {
             switch (Settings.ReadPermission)
             {
@@ -132,7 +131,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.ReadPermissionCallback == null) return false;
-                    return Settings.ReadPermissionCallback(clientId, networkedBehaviour);
+                    return Settings.ReadPermissionCallback(clientId, this);
                 }
             }
 
@@ -140,7 +139,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void WriteDelta(Stream stream)
+        public override void WriteDelta(Stream stream)
         {
             using (PooledBitWriter writer = PooledBitWriter.Get(stream))
             {
@@ -189,7 +188,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void WriteField(Stream stream)
+        public override void WriteField(Stream stream)
         {
             using (PooledBitWriter writer = PooledBitWriter.Get(stream))
             {
@@ -202,7 +201,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void ReadField(Stream stream)
+        public override void ReadField(Stream stream)
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
@@ -216,7 +215,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void ReadDelta(Stream stream, bool keepDirtyDelta)
+        public override void ReadDelta(Stream stream, bool keepDirtyDelta)
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
@@ -383,12 +382,6 @@ namespace MLAPI.NetworkedVar.Collections
                     }
                 }
             }
-        }
-
-        /// <inheritdoc />
-        public void SetNetworkedBehaviour(NetworkedBehaviour behaviour)
-        {
-            networkedBehaviour = behaviour;
         }
 
         /// <inheritdoc />

--- a/MLAPI/NetworkedVar/Collections/NetworkedSet.cs
+++ b/MLAPI/NetworkedVar/Collections/NetworkedSet.cs
@@ -11,11 +11,10 @@ namespace MLAPI.NetworkedVar.Collections
     /// Event based networkedVar container for syncing Sets
     /// </summary>
     /// <typeparam name="T">The type for the set</typeparam>
-    public class NetworkedSet<T> : ISet<T>, INetworkedVar
+    public class NetworkedSet<T> : NetworkedVarBase, ISet<T>
     {
         private readonly ISet<T> set = new HashSet<T>();
         private readonly List<NetworkedSetEvent<T>> dirtyEvents = new List<NetworkedSetEvent<T>>();
-        private NetworkedBehaviour networkedBehaviour;
 
         /// <summary>
         /// Gets the last time the variable was synced
@@ -76,14 +75,14 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void ResetDirty()
+        public override void ResetDirty()
         {
             dirtyEvents.Clear();
             LastSyncedTime = NetworkingManager.Singleton.NetworkTime;
         }
 
         /// <inheritdoc />
-        public bool IsDirty()
+        public override bool IsDirty()
         {
             if (dirtyEvents.Count == 0) return false;
             if (Settings.SendTickrate == 0) return true;
@@ -93,13 +92,13 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public string GetChannel()
+        public override string GetChannel()
         {
             return Settings.SendChannel;
         }
 
         /// <inheritdoc />
-        public bool CanClientWrite(ulong clientId)
+        public override bool CanClientWrite(ulong clientId)
         {
             switch (Settings.WritePermission)
             {
@@ -112,7 +111,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.WritePermissionCallback == null) return false;
-                    return Settings.WritePermissionCallback(clientId, networkedBehaviour);
+                    return Settings.WritePermissionCallback(clientId, this);
                 }
             }
 
@@ -120,7 +119,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public bool CanClientRead(ulong clientId)
+        public override bool CanClientRead(ulong clientId)
         {
             switch (Settings.ReadPermission)
             {
@@ -133,7 +132,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.ReadPermissionCallback == null) return false;
-                    return Settings.ReadPermissionCallback(clientId, networkedBehaviour);
+                    return Settings.ReadPermissionCallback(clientId, this);
                 }
             }
 
@@ -141,7 +140,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void WriteDelta(Stream stream)
+        public override void WriteDelta(Stream stream)
         {
             using (PooledBitWriter writer = PooledBitWriter.Get(stream))
             {
@@ -173,7 +172,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void WriteField(Stream stream)
+        public override void WriteField(Stream stream)
         {
             using (PooledBitWriter writer = PooledBitWriter.Get(stream))
             {
@@ -187,7 +186,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void ReadField(Stream stream)
+        public override void ReadField(Stream stream)
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
@@ -202,7 +201,7 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public void ReadDelta(Stream stream, bool keepDirtyDelta)
+        public override void ReadDelta(Stream stream, bool keepDirtyDelta)
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
@@ -285,12 +284,6 @@ namespace MLAPI.NetworkedVar.Collections
                     }
                 }
             }
-        }
-
-        /// <inheritdoc />
-        public void SetNetworkedBehaviour(NetworkedBehaviour behaviour)
-        {
-            networkedBehaviour = behaviour;
         }
 
         /// <inheritdoc />

--- a/MLAPI/NetworkedVar/Collections/NetworkedSet.cs
+++ b/MLAPI/NetworkedVar/Collections/NetworkedSet.cs
@@ -112,7 +112,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.WritePermissionCallback == null) return false;
-                    return Settings.WritePermissionCallback(clientId);
+                    return Settings.WritePermissionCallback(clientId, networkedBehaviour);
                 }
             }
 
@@ -133,7 +133,7 @@ namespace MLAPI.NetworkedVar.Collections
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.ReadPermissionCallback == null) return false;
-                    return Settings.ReadPermissionCallback(clientId);
+                    return Settings.ReadPermissionCallback(clientId, networkedBehaviour);
                 }
             }
 

--- a/MLAPI/NetworkedVar/NetworkedVar.cs
+++ b/MLAPI/NetworkedVar/NetworkedVar.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
 using System;
@@ -128,7 +128,7 @@ namespace MLAPI.NetworkedVar
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.ReadPermissionCallback == null) return false;
-                    return Settings.ReadPermissionCallback(clientId);
+                    return Settings.ReadPermissionCallback(clientId, networkedBehaviour);
                 }
             }
             return true;
@@ -154,7 +154,7 @@ namespace MLAPI.NetworkedVar
                 case NetworkedVarPermission.Custom:
                 {
                     if (Settings.WritePermissionCallback == null) return false;
-                    return Settings.WritePermissionCallback(clientId);
+                    return Settings.WritePermissionCallback(clientId, networkedBehaviour);
                 }
             }
 

--- a/MLAPI/NetworkedVar/NetworkedVarBase.cs
+++ b/MLAPI/NetworkedVar/NetworkedVarBase.cs
@@ -3,61 +3,63 @@ using System.IO;
 namespace MLAPI.NetworkedVar
 {
     /// <summary>
-    /// Interface for networked value containers
+    /// Abstract base class for networked value containers
     /// </summary>
-    public interface INetworkedVar
+    public abstract class NetworkedVarBase
     {
+        /// <summary>
+        /// The NetworkedBehaviour the container belongs to.
+        /// </summary>
+        public NetworkedBehaviour networkedBehaviour
+        {
+            get; internal set;
+        }
         /// <summary>
         /// Returns the name of the channel to be used for syncing
         /// </summary>
         /// <returns>The name of the channel to be used for syncing</returns>
-        string GetChannel();
+        public abstract string GetChannel();
         /// <summary>
         /// Resets the dirty state and marks the variable as synced / clean
         /// </summary>
-        void ResetDirty();
+        public abstract void ResetDirty();
         /// <summary>
         /// Gets Whether or not the container is dirty
         /// </summary>
         /// <returns>Whether or not the container is dirty</returns>
-        bool IsDirty();
+        public abstract bool IsDirty();
         /// <summary>
         /// Gets Whether or not a specific client can write to the varaible
         /// </summary>
         /// <param name="clientId">The clientId of the remote client</param>
         /// <returns>Whether or not the client can write to the variable</returns>
-        bool CanClientWrite(ulong clientId);
+        public abstract bool CanClientWrite(ulong clientId);
         /// <summary>
         /// Gets Whether or not a specific client can read to the varaible
         /// </summary>
         /// <param name="clientId">The clientId of the remote client</param>
         /// <returns>Whether or not the client can read to the variable</returns>
-        bool CanClientRead(ulong clientId);
+        public abstract bool CanClientRead(ulong clientId);
         /// <summary>
         /// Writes the dirty changes, that is, the changes since the variable was last dirty, to the writer
         /// </summary>
         /// <param name="stream">The stream to write the dirty changes to</param>
-        void WriteDelta(Stream stream);
+        public abstract void WriteDelta(Stream stream);
         /// <summary>
         /// Writes the complete state of the variable to the writer
         /// </summary>
         /// <param name="stream">The stream to write the state to</param>
-        void WriteField(Stream stream);
+        public abstract void WriteField(Stream stream);
         /// <summary>
         /// Reads the complete state from the reader and applies it
         /// </summary>
         /// <param name="stream">The stream to read the state from</param>
-        void ReadField(Stream stream);
+        public abstract void ReadField(Stream stream);
         /// <summary>
         /// Reads delta from the reader and applies them to the internal value
         /// </summary>
         /// <param name="stream">The stream to read the delta from</param>
         /// <param name="keepDirtyDelta">Whether or not the delta should be kept as dirty or consumed</param>
-        void ReadDelta(Stream stream, bool keepDirtyDelta);
-        /// <summary>
-        /// Sets NetworkedBehaviour the container belongs to.
-        /// </summary>
-        /// <param name="behaviour">The behaviour the container behaves to</param>
-        void SetNetworkedBehaviour(NetworkedBehaviour behaviour);
+        public abstract void ReadDelta(Stream stream, bool keepDirtyDelta);
     }
 }

--- a/MLAPI/NetworkedVar/NetworkedVarSettings.cs
+++ b/MLAPI/NetworkedVar/NetworkedVarSettings.cs
@@ -4,8 +4,8 @@ namespace MLAPI.NetworkedVar
     /// Delegate type for permission checking
     /// </summary>
     /// <param name="clientId">The clientId whose permissions to check</param>
-    /// <param name="networkedBehaviour">The NetworkedBehaviour on which the var is defined</param>
-    public delegate bool NetworkedVarPermissionsDelegate(ulong clientId, NetworkedBehaviour networkedBehaviour);
+    /// <param name="networkedVar">The networked var whose permissions to check</param>
+    public delegate bool NetworkedVarPermissionsDelegate(ulong clientId, NetworkedVarBase networkedVar);
 
     /// <summary>
     /// The settings class used by the build in NetworkVar implementations

--- a/MLAPI/NetworkedVar/NetworkedVarSettings.cs
+++ b/MLAPI/NetworkedVar/NetworkedVarSettings.cs
@@ -4,7 +4,8 @@ namespace MLAPI.NetworkedVar
     /// Delegate type for permission checking
     /// </summary>
     /// <param name="clientId">The clientId whose permissions to check</param>
-    public delegate bool NetworkedVarPermissionsDelegate(ulong clientId);
+    /// <param name="networkedBehaviour">The NetworkedBehaviour on which the var is defined</param>
+    public delegate bool NetworkedVarPermissionsDelegate(ulong clientId, NetworkedBehaviour networkedBehaviour);
 
     /// <summary>
     /// The settings class used by the build in NetworkVar implementations

--- a/MLAPI/Reflection/TypeExtensions.cs
+++ b/MLAPI/Reflection/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace MLAPI.Reflection
 {
@@ -14,7 +14,17 @@ namespace MLAPI.Reflection
             }
             return false;
         }
-        
+
+        internal static bool HasAncestorType(this Type type, Type baseType)
+        {
+            for (Type currentType = type; currentType != null; currentType = currentType.BaseType)
+            {
+                if (currentType == baseType)
+                    return true;
+            }
+            return false;
+        }
+
         internal static bool IsNullable(this Type type)
         {
             if (!type.IsValueType) return true; // ref-type


### PR DESCRIPTION
Also switch `INetworkedVar` to an abstract `NetworkedVarBase` class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/midlevel/mlapi/312)
<!-- Reviewable:end -->
