### PR TITLE
Print which Networked prefab is missing.

### DIFF
--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -406,9 +406,13 @@ namespace MLAPI
                 {
                     if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError("Networked prefab cannot be null");
                 }
-                else if (NetworkConfig.NetworkedPrefabs[i].Prefab.GetComponent<NetworkedObject>() == null)
+                 else if (NetworkConfig.NetworkedPrefabs[i].Prefab.GetComponent<NetworkedObject>() == null)
                 {
-                    if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError("Networked prefab is missing a NetworkedObject component");
+                    if (LogHelper.CurrentLogLevel <= LogLevel.Error)
+                    {
+                        LogHelper.LogError("Networked prefab " + NetworkConfig.NetworkedPrefabs[i].Prefab.name +
+                                           " is missing a NetworkedObject component");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
When a Networked prefab is missing it just prints "Networked prefab is missing a NetworkedObject component. It would be nice if it would also print the name because it takes a lot of time to check through all the prefabs.