### PR TITLE
Serializer now works with enums of different type (fix for issue #388)

### DIFF
--- a/MLAPI/Serialization/BitReader.cs
+++ b/MLAPI/Serialization/BitReader.cs
@@ -156,7 +156,7 @@ namespace MLAPI.Serialization
             if (type == typeof(char))
                 return ReadCharPacked();
             if (type.IsEnum)
-                return ReadInt32Packed();
+                return ReadObjectPacked(System.Enum.GetUnderlyingType(type));
             if (type == typeof(GameObject))
             {
                 ulong networkId = ReadUInt64Packed();

--- a/MLAPI/Serialization/BitWriter.cs
+++ b/MLAPI/Serialization/BitWriter.cs
@@ -182,7 +182,19 @@ namespace MLAPI.Serialization
             }
             else if (value.GetType().IsEnum)
             {
-                WriteInt32Packed((int)value);
+                var underlyingType = System.Enum.GetUnderlyingType(value.GetType());
+
+                if (underlyingType == typeof(Int32))
+                    WriteInt32Packed((int)value);
+                else if (underlyingType == typeof(byte))
+                    WriteByte((byte)value);
+                else if (underlyingType == typeof(Int16))
+                    WriteInt16Packed((short)value);
+                else else if (underlyingType == typeof(Int64))
+                    WriteInt64Packed((long)value);
+                else
+                    WriteObjectPacked(Convert.ChangeType(value, underlyingType));
+
                 return;
             }
             else if (value is GameObject)


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/issues/388

Its good practice to keep your enums as small as possible, if the enum has fewer than 255 values might as well make it a byte. Before now this was not supported, this should make sure the serializers support that. 