### PR TITLE
Feature/fix remove max object updates

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/NetworkingManagerEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkingManagerEditor.cs
@@ -26,7 +26,6 @@ public class NetworkingManagerEditor : Editor
     private SerializedProperty receiveTickrateProperty;
     private SerializedProperty maxReceiveEventsPerTickRateProperty;
     private SerializedProperty eventTickrateProperty;
-    private SerializedProperty maxObjectUpdatesPerTickProperty;
     private SerializedProperty clientConnectionBufferTimeoutProperty;
     private SerializedProperty connectionApprovalProperty;
     private SerializedProperty secondsHistoryProperty;
@@ -306,7 +305,6 @@ public class NetworkingManagerEditor : Editor
 
             using (new EditorGUI.DisabledScope(!networkingManager.NetworkConfig.EnableNetworkedVar))
             {
-                EditorGUILayout.PropertyField(maxObjectUpdatesPerTickProperty);
                 EditorGUILayout.PropertyField(ensureNetworkedVarLengthSafetyProperty);
             }
 


### PR DESCRIPTION
This caused an exception in the editor when trying to access the inspector because the SerializedProperty doesn't get initialized anymore. @mattwalsh-unity I'm merging this, please could you verify whether it was intended?