### PR TITLE
docs: replaced licence for license in getting started

### DIFF
--- a/docs/_docs/getting-started/index.md
+++ b/docs/_docs/getting-started/index.md
@@ -53,7 +53,7 @@ Simply add the part of the permalink after ``wiki``. The above examples entry in
 ```
 
 ### License
-Documentation on the wiki is licensed under the following license
+Documentation on the wiki is licensed under the following license:
 ```
 This is free and unencumbered software released into the public domain.
 

--- a/docs/_docs/getting-started/index.md
+++ b/docs/_docs/getting-started/index.md
@@ -52,8 +52,8 @@ Simply add the part of the permalink after ``wiki``. The above examples entry in
   - my-long-topic-name
 ```
 
-### Licence
-Documentation on the wiki is licenced under the follwing licence
+### License
+Documentation on the wiki is licensed under the follwing license
 ```
 This is free and unencumbered software released into the public domain.
 

--- a/docs/_docs/getting-started/index.md
+++ b/docs/_docs/getting-started/index.md
@@ -53,7 +53,7 @@ Simply add the part of the permalink after ``wiki``. The above examples entry in
 ```
 
 ### License
-Documentation on the wiki is licensed under the follwing license
+Documentation on the wiki is licensed under the following license
 ```
 This is free and unencumbered software released into the public domain.
 


### PR DESCRIPTION
It was mispelling licence instead of license