### PR TITLE
refactor: move client iteration to outermost loop

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedObject.cs
@@ -21,10 +21,6 @@ namespace MLAPI
     [AddComponentMenu("MLAPI/NetworkedObject", -99)]
     public sealed class NetworkedObject : MonoBehaviour
     {
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
-        public static ProfilerMarker s_NetworkedBehaviourUpdate = new ProfilerMarker("MLAPI.NetworkedObject.NetworkedBehaviourUpdate");
-#endif
-
         private void OnValidate()
         {
             // Set this so the hash can be serialized on Scene objects. For prefabs, they are generated at runtime.
@@ -537,36 +533,6 @@ namespace MLAPI
                     }
                 }
                 return _childNetworkedBehaviours;
-            }
-        }
-
-        internal static void NetworkedBehaviourUpdate()
-        {
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
-            s_NetworkedBehaviourUpdate.Begin();
-#endif
-
-            try
-            {
-                if (SpawnManager.SpawnedObjectsList.Count == 0)
-                    return;
-
-                foreach (var sobj in SpawnManager.SpawnedObjectsList)
-                {
-                    // Sync all vars
-                    for (int j = 0;
-                        j < sobj.childNetworkedBehaviours.Count;
-                        j++)
-                    {
-                        sobj.childNetworkedBehaviours[j].VarUpdate();
-                    }
-                }
-            }
-            finally
-            {
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
-                s_NetworkedBehaviourUpdate.End();
-#endif
             }
         }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -704,7 +704,7 @@ namespace MLAPI
                     if (NetworkConfig.EnableNetworkedVar)
                     {
                         // Do NetworkedVar updates
-                        NetworkedObject.NetworkedBehaviourUpdate();
+                        NetworkedBehaviour.NetworkedBehaviourUpdate();
                     }
 
                     if (!IsServer && NetworkConfig.EnableMessageBuffering)

--- a/com.unity.multiplayer.mlapi/Runtime/NetworkedVar/NetworkedVar.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/NetworkedVar/NetworkedVar.cs
@@ -23,7 +23,7 @@ namespace MLAPI.NetworkedVar
         /// <summary>
         /// Gets the last time the variable was synced
         /// </summary>
-        public float LastSyncedTime { get; internal set; }        
+        public float LastSyncedTime { get; internal set; }
         /// <summary>
         /// Delegate type for value changed event
         /// </summary>
@@ -35,13 +35,13 @@ namespace MLAPI.NetworkedVar
         /// </summary>
         public OnValueChangedDelegate OnValueChanged;
         private NetworkedBehaviour networkedBehaviour;
-     
+
         /// <summary>
         /// Creates a NetworkedVar with the default value and settings
         /// </summary>
         public NetworkedVar()
         {
-            
+
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace MLAPI.NetworkedVar
         {
             ReadDelta(stream, false);
         }
-        
+
         /// <inheritdoc />
         public void WriteField(Stream stream)
         {
@@ -207,7 +207,7 @@ namespace MLAPI.NetworkedVar
             return Settings.SendChannel;
         }
     }
-    
+
     /// <summary>
     /// A NetworkedVar that holds strings and support serialization
     /// </summary>
@@ -271,7 +271,7 @@ namespace MLAPI.NetworkedVar
         /// <inheritdoc />
         public NetworkedVarSByte(NetworkedVarSettings settings, sbyte value) : base(settings, value) { }
     }
-    
+
     /// <summary>
     /// A NetworkedVar that holds ushorts and support serialization
     /// </summary>


### PR DESCRIPTION
This change is key to allowing us to do AOI; it moves the 'for each client' to the outer loop.