### PR TITLE
Fix/migration cleanup lost changes

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -336,7 +336,7 @@ namespace MLAPI.Configuration
                     writer.WriteUInt16Packed(ProtocolVersion);
                     writer.WriteString(MLAPIConstants.MLAPI_PROTOCOL_VERSION);
 
-                    if (!AllowRuntimeSceneChanges)
+                    if (EnableSceneManagement && !AllowRuntimeSceneChanges)
                     {
                         for (int i = 0; i < RegisteredScenes.Count; i++)
                         {

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -342,21 +342,7 @@ namespace MLAPI.Messaging
                             }
                         }
 
-                        // Clean up the diffed scene objects. I.E scene objects that have been destroyed
-                        if (SpawnManager.pendingSoftSyncObjects.Count > 0)
-                        {
-                            List<NetworkedObject> objectsToDestroy = new List<NetworkedObject>();
-
-                            foreach (KeyValuePair<ulong, NetworkedObject> pair in SpawnManager.pendingSoftSyncObjects)
-                            {
-                                objectsToDestroy.Add(pair.Value);
-                            }
-
-                            for (int i = 0; i < objectsToDestroy.Count; i++)
-                            {
-                                MonoBehaviour.Destroy(objectsToDestroy[i].gameObject);
-                            }
-                        }
+                        SpawnManager.CleanDiffedSceneObjects();
 
                         NetworkingManager.Singleton.IsConnectedClient = true;
 

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -342,6 +342,22 @@ namespace MLAPI.Messaging
                             }
                         }
 
+                        // Clean up the diffed scene objects. I.E scene objects that have been destroyed
+                        if (SpawnManager.pendingSoftSyncObjects.Count > 0)
+                        {
+                            List<NetworkedObject> objectsToDestroy = new List<NetworkedObject>();
+
+                            foreach (KeyValuePair<ulong, NetworkedObject> pair in SpawnManager.pendingSoftSyncObjects)
+                            {
+                                objectsToDestroy.Add(pair.Value);
+                            }
+
+                            for (int i = 0; i < objectsToDestroy.Count; i++)
+                            {
+                                MonoBehaviour.Destroy(objectsToDestroy[i].gameObject);
+                            }
+                        }
+
                         NetworkingManager.Singleton.IsConnectedClient = true;
 
                         NetworkingManager.Singleton.InvokeOnClientConnectedCallback(NetworkingManager.Singleton.LocalClientId);

--- a/com.unity.multiplayer.mlapi/Runtime/Serialization/BitWriter.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Serialization/BitWriter.cs
@@ -52,11 +52,14 @@ namespace MLAPI.Serialization
         /// <param name="value">The object to write</param>
         public void WriteObjectPacked(object value)
         {
-            if (value == null || value.GetType().IsNullable())
-            {
-                WriteBool(value == null);
+            // Check unitys custom null checks
+            bool isNull = value == null || (value is UnityEngine.Object && ((UnityEngine.Object)value) == null);
 
-                if (value == null)
+            if (isNull || value.GetType().IsNullable())
+            {
+                WriteBool(isNull);
+
+                if (isNull)
                 {
                     return;
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/SpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/SpawnManager.cs
@@ -574,6 +574,25 @@ namespace MLAPI.Spawning
             }
         }
 
+        internal static void CleanDiffedSceneObjects()
+        {
+            // Clean up the diffed scene objects. I.E scene objects that have been destroyed
+            if (pendingSoftSyncObjects.Count > 0)
+            {
+                List<NetworkedObject> objectsToDestroy = new List<NetworkedObject>();
+
+                foreach (KeyValuePair<ulong, NetworkedObject> pair in pendingSoftSyncObjects)
+                {
+                    objectsToDestroy.Add(pair.Value);
+                }
+
+                for (int i = 0; i < objectsToDestroy.Count; i++)
+                {
+                    MonoBehaviour.Destroy(objectsToDestroy[i].gameObject);
+                }
+            }
+        }
+
         internal static void ServerSpawnSceneObjectsOnStartSweep()
         {
             NetworkedObject[] networkedObjects = MonoBehaviour.FindObjectsOfType<NetworkedObject>();


### PR DESCRIPTION
This PR adds features and bug fixes which were removed by accident when merging our internal changes into the new develop branch.
Albin already approved this PR in our internal repo. @mattwalsh-unity since you made the commits which migrated those, could you confirm that these (especially the soft sync object part) weren't removed on purpose?