### PR TITLE
fix: Downgrade Unity Collections Version and Target Unity Editor Version (2019.4 Compatibility)

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -1,7 +1,7 @@
 # Editors where tests will happen. The first entry of this array is also used
 # for validation
 test_editors:
-  - 2020.2
+  - 2019.4
   - trunk
 
 # Platforms that will be tested. The first entry in this array will also

--- a/com.unity.multiplayer.mlapi/Runtime/Transports/ENET.meta
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/ENET.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a54280d111d77e842b00fb6a2f4d78cb
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/package.json
+++ b/com.unity.multiplayer.mlapi/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "com.unity.multiplayer.mlapi",
-  "displayName": "MLAPI Networking Library",
-  "version": "0.0.1-preview.1",
-  "unity": "2019.4",
-  "unityRelease": "8f1",
-  "description": "This the Core Unity Mid-level API that provides core SDK for multiplayer games within unity",
-  "keywords": [
-    "unity"
-  ],
-  "type": "library",
-  "hideInEditor": false,
-  "dependencies": {
-    "com.unity.nuget.mono-cecil": "1.10.1-preview.1",
-    "com.unity.collections": "0.14.0-preview.16"
-  }
+    "name": "com.unity.multiplayer.mlapi",
+    "displayName": "MLAPI Networking Library",
+    "version": "0.0.1-preview.1",
+    "unity": "2019.4",
+    "unityRelease": "8f1",
+    "description": "This the Core Unity Mid-level API that provides core SDK for multiplayer games within unity",
+    "keywords": [
+        "unity"
+    ],
+    "type": "library",
+    "hideInEditor": false,
+    "dependencies": {
+        "com.unity.nuget.mono-cecil": "1.10.1-preview.1",
+        "com.unity.collections": "0.9.0-preview.6"
+    }
 }


### PR DESCRIPTION
I tested this setup in an empty Unity 2019.4 (LTS) project and it seems OK.
I think we should downgrade our target editor version and collections version now, so that we could keep our eyes on versions.

---

1. Yamato should target Unity Editor version `2019.4`

2. We should be using Unity Collections 0.9.0:
`"com.unity.collections": "0.14.0-preview.16"` is for `2020.1+`
`"com.unity.collections": "0.9.0-preview.6"` is for `2019.3+`

<img width="243" src="https://user-images.githubusercontent.com/12574651/102887665-3ce9ea00-444f-11eb-906e-2a2f6f064309.png">