### PR TITLE
[Wiki] InvokeServerRpc(MyServerRpc, ...) changed to "MyServerRPC" 

### DIFF
--- a/docs/_docs/the-basics/messaging-system.md
+++ b/docs/_docs/the-basics/messaging-system.md
@@ -35,7 +35,7 @@ public class Example : NetworkedBehaviour
           }
           else
           {
-              InvokeServerRpc(MyServerRpc, Random.Range(-50, 50));
+              InvokeServerRpc(MyServerRPC, Random.Range(-50, 50));
           }
       }
   }


### PR DESCRIPTION
In the page: https://mlapi.network/wiki/messaging-system/ Convenience Example section
`InvokeServerRpc(MyServerRpc, Random.Range(-50, 50));` "Rpc" throws `The name 'MyServerRpc' does not exist in the current context` and should be changed to capital letters.