### PR TITLE
ci: downgrade target unity version and remove windows platform target

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -2,11 +2,16 @@
 # for validation
 test_editors:
   - 2019.4
+  - 2021.1
   - trunk
 
 # Platforms that will be tested. The first entry in this array will also
 # be used for validation
 test_platforms:
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
   - name: mac
     type: Unity::VM::osx
     image: package-ci/mac:stable

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -1,16 +1,12 @@
 # Editors where tests will happen. The first entry of this array is also used
 # for validation
 test_editors:
-  - 2020.2
+  - 2019.4
   - trunk
 
 # Platforms that will be tested. The first entry in this array will also
 # be used for validation
 test_platforms:
-  - name: win
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: b1.large
   - name: mac
     type: Unity::VM::osx
     image: package-ci/mac:stable

--- a/com.unity.multiplayer.mlapi/package.json
+++ b/com.unity.multiplayer.mlapi/package.json
@@ -12,6 +12,6 @@
   "hideInEditor": false,
   "dependencies": {
     "com.unity.nuget.mono-cecil": "1.10.1-preview.1",
-    "com.unity.collections": "0.14.0-preview.16"
+    "com.unity.collections": "0.9.0-preview.6"
   }
 }


### PR DESCRIPTION
As per @JesseOlmer's suggestion, this PR is an attempt to downgrade MLAPI package **targeting Unity 2019.4 and removing Windows platform target temporarily**. An ILPP issue on 2019.4 and 2020.1 that's specific to Windows platform is holding us back but while working on that issue, we might be able to keep working on 2019.4 target.