### PR TITLE
refactor: ILPP workarounds for 2019.4 and 2020.2+ bugs 

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -1,6 +1,7 @@
 # Editors where tests will happen. The first entry of this array is also used
 # for validation
 test_editors:
+  - 2019.4
   - 2020.2
   - trunk
 

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/CodeGenHelpers.cs
@@ -12,10 +12,6 @@ using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 using UnityEngine;
 
-#if UNITY_2021_1_OR_NEWER
-#warning Built-in Unity ILPP needs to be re-enabled after fixing self-referencing assembly reload issue on 2021.1+ and trunk
-#endif
-
 #if !UNITY_2019_4_OR_NEWER
 #error MLAPI requires Unity 2019.4 or newer
 #endif

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/CodeGenHelpers.cs
@@ -170,7 +170,7 @@ namespace MLAPI.Editor.CodeGen
             });
         }
 
-        public static AssemblyDefinition AssemblyDefinitionFor(ICompiledAssembly compiledAssembly)
+        public static Mono.Cecil.AssemblyDefinition AssemblyDefinitionFor(ICompiledAssembly compiledAssembly)
         {
             var assemblyResolver = new PostProcessorAssemblyResolver(compiledAssembly);
             var readerParameters = new ReaderParameters
@@ -182,7 +182,7 @@ namespace MLAPI.Editor.CodeGen
                 ReadingMode = ReadingMode.Immediate
             };
 
-            var assemblyDefinition = AssemblyDefinition.ReadAssembly(new MemoryStream(compiledAssembly.InMemoryAssembly.PeData), readerParameters);
+            var assemblyDefinition = Mono.Cecil.AssemblyDefinition.ReadAssembly(new MemoryStream(compiledAssembly.InMemoryAssembly.PeData), readerParameters);
 
             //apparently, it will happen that when we ask to resolve a type that lives inside MLAPI.Runtime, and we
             //are also postprocessing MLAPI.Runtime, type resolving will fail, because we do not actually try to resolve

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/CodeGenHelpers.cs
@@ -12,6 +12,10 @@ using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 using UnityEngine;
 
+#if !UNITY_2020_2_OR_NEWER && !UNITY_2019_4_OR_NEWER
+#error MLAPI requires Unity 2019.4 or newer
+#endif
+
 namespace MLAPI.Editor.CodeGen
 {
     internal static class CodeGenHelpers
@@ -170,7 +174,7 @@ namespace MLAPI.Editor.CodeGen
             });
         }
 
-        public static Mono.Cecil.AssemblyDefinition AssemblyDefinitionFor(ICompiledAssembly compiledAssembly)
+        public static AssemblyDefinition AssemblyDefinitionFor(ICompiledAssembly compiledAssembly)
         {
             var assemblyResolver = new PostProcessorAssemblyResolver(compiledAssembly);
             var readerParameters = new ReaderParameters
@@ -182,7 +186,7 @@ namespace MLAPI.Editor.CodeGen
                 ReadingMode = ReadingMode.Immediate
             };
 
-            var assemblyDefinition = Mono.Cecil.AssemblyDefinition.ReadAssembly(new MemoryStream(compiledAssembly.InMemoryAssembly.PeData), readerParameters);
+            var assemblyDefinition = AssemblyDefinition.ReadAssembly(new MemoryStream(compiledAssembly.InMemoryAssembly.PeData), readerParameters);
 
             //apparently, it will happen that when we ask to resolve a type that lives inside MLAPI.Runtime, and we
             //are also postprocessing MLAPI.Runtime, type resolving will fail, because we do not actually try to resolve

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/CodeGenHelpers.cs
@@ -12,7 +12,11 @@ using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 using UnityEngine;
 
-#if !UNITY_2020_2_OR_NEWER && !UNITY_2019_4_OR_NEWER
+#if UNITY_2021_1_OR_NEWER
+#warning Built-in Unity ILPP needs to be re-enabled after fixing self-referencing assembly reload issue on 2021.1+ and trunk
+#endif
+
+#if !UNITY_2019_4_OR_NEWER
 #error MLAPI requires Unity 2019.4 or newer
 #endif
 

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs
@@ -1,4 +1,4 @@
-#if !UNITY_2020_2_OR_NEWER
+#if !UNITY_2020_2_OR_NEWER || UNITY_2021_1_OR_NEWER
 using System.IO;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs
@@ -1,4 +1,4 @@
-#if !UNITY_2020_2_OR_NEWER || UNITY_2021_1_OR_NEWER
+#if !UNITY_2020_2_OR_NEWER
 using System.IO;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using Unity.CompilationPipeline.Common.ILPostProcessing;
+
+namespace MLAPI.Editor.CodeGen
+{
+    internal class ILPostProcessCompiledAssembly : ICompiledAssembly
+    {
+        readonly string m_AssemblyFilename;
+        readonly string m_OutputPath;
+        InMemoryAssembly m_InMemoryAssembly;
+
+        public ILPostProcessCompiledAssembly(string assName, string[] refs, string[] defines, string outputPath)
+        {
+            m_AssemblyFilename = assName;
+            Name = Path.GetFileNameWithoutExtension(m_AssemblyFilename);
+            References = refs;
+            Defines = defines;
+
+            m_OutputPath = outputPath;
+        }
+
+        public InMemoryAssembly InMemoryAssembly
+        {
+            get { return CreateOrGetInMemoryAssembly(); }
+            set { m_InMemoryAssembly = value; }
+        }
+
+        public string Name { get; set; }
+        public string[] References { get; set; }
+        public string[] Defines { get; private set; }
+
+        private InMemoryAssembly CreateOrGetInMemoryAssembly()
+        {
+            if (m_InMemoryAssembly != null)
+            {
+                return m_InMemoryAssembly;
+            }
+
+            byte[] peData = File.ReadAllBytes(Path.Combine(m_OutputPath, m_AssemblyFilename));
+
+            var pdbFileName = Path.GetFileNameWithoutExtension(m_AssemblyFilename) + ".pdb";
+            byte[] pdbData = File.ReadAllBytes(Path.Combine(m_OutputPath, pdbFileName));
+
+            m_InMemoryAssembly = new InMemoryAssembly(peData, pdbData);
+            return m_InMemoryAssembly;
+        }
+    }
+}

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs
@@ -1,3 +1,4 @@
+#if !UNITY_2020_2_OR_NEWER
 using System.IO;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 
@@ -5,44 +6,37 @@ namespace MLAPI.Editor.CodeGen
 {
     internal class ILPostProcessCompiledAssembly : ICompiledAssembly
     {
-        readonly string m_AssemblyFilename;
-        readonly string m_OutputPath;
-        InMemoryAssembly m_InMemoryAssembly;
+        private readonly string m_AssemblyFilename;
+        private readonly string m_OutputPath;
+        private InMemoryAssembly m_InMemoryAssembly;
 
-        public ILPostProcessCompiledAssembly(string assName, string[] refs, string[] defines, string outputPath)
+        public ILPostProcessCompiledAssembly(string asmName, string[] refs, string[] defines, string outputPath)
         {
-            m_AssemblyFilename = assName;
+            m_AssemblyFilename = asmName;
             Name = Path.GetFileNameWithoutExtension(m_AssemblyFilename);
             References = refs;
             Defines = defines;
-
             m_OutputPath = outputPath;
         }
 
+        public string Name { get; }
+        public string[] References { get; }
+        public string[] Defines { get; }
+
         public InMemoryAssembly InMemoryAssembly
         {
-            get { return CreateOrGetInMemoryAssembly(); }
-            set { m_InMemoryAssembly = value; }
-        }
-
-        public string Name { get; set; }
-        public string[] References { get; set; }
-        public string[] Defines { get; private set; }
-
-        private InMemoryAssembly CreateOrGetInMemoryAssembly()
-        {
-            if (m_InMemoryAssembly != null)
+            get
             {
+                if (m_InMemoryAssembly == null)
+                {
+                    m_InMemoryAssembly = new InMemoryAssembly(
+                        File.ReadAllBytes(Path.Combine(m_OutputPath, m_AssemblyFilename)),
+                        File.ReadAllBytes(Path.Combine(m_OutputPath, $"{Path.GetFileNameWithoutExtension(m_AssemblyFilename)}.pdb")));
+                }
+
                 return m_InMemoryAssembly;
             }
-
-            byte[] peData = File.ReadAllBytes(Path.Combine(m_OutputPath, m_AssemblyFilename));
-
-            var pdbFileName = Path.GetFileNameWithoutExtension(m_AssemblyFilename) + ".pdb";
-            byte[] pdbData = File.ReadAllBytes(Path.Combine(m_OutputPath, pdbFileName));
-
-            m_InMemoryAssembly = new InMemoryAssembly(peData, pdbData);
-            return m_InMemoryAssembly;
         }
     }
 }
+#endif

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs.meta
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessCompiledAssembly.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c63d199856aa44f4581ec4de75bf3f44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
@@ -4,16 +4,6 @@ using Unity.CompilationPipeline.Common.ILPostProcessing;
 
 namespace MLAPI.Editor.CodeGen
 {
-    internal class AssemblyDefinition
-    {
-        public string name = "";
-        public string[] references = new string[0];
-        public string[] optionalUnityReferences = new string[0];
-        public string[] includePlatforms = new string[0];
-        public string[] excludePlatforms = new string[0];
-        public string[] precompiledReferences = new string[0];
-    }
-
     public abstract class ILPostProcessor
     {
         public virtual bool WillProcess(ICompiledAssembly compiledAssembly) => false;

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
@@ -1,15 +1,13 @@
-#if !USE_UNITY_ILPP
-
+#if !UNITY_2020_2_OR_NEWER
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 
 namespace MLAPI.Editor.CodeGen
 {
     public abstract class ILPostProcessor
     {
-        public virtual bool WillProcess(ICompiledAssembly compiledAssembly) => false;
-        public virtual ILPostProcessResult Process(ICompiledAssembly compiledAssembly) => null;
-        public virtual ILPostProcessor GetInstance() => null;
+        public abstract bool WillProcess(ICompiledAssembly compiledAssembly);
+        public abstract ILPostProcessResult Process(ICompiledAssembly compiledAssembly);
+        public abstract ILPostProcessor GetInstance();
     }
 }
-
 #endif

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
@@ -1,4 +1,4 @@
-#if !UNITY_2020_2_OR_NEWER || UNITY_2021_1_OR_NEWER
+#if !UNITY_2020_2_OR_NEWER
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 
 namespace MLAPI.Editor.CodeGen

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
@@ -1,4 +1,4 @@
-#if !UNITY_2020_2_OR_NEWER
+#if !UNITY_2020_2_OR_NEWER || UNITY_2021_1_OR_NEWER
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 
 namespace MLAPI.Editor.CodeGen

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs
@@ -1,0 +1,25 @@
+#if !USE_UNITY_ILPP
+
+using Unity.CompilationPipeline.Common.ILPostProcessing;
+
+namespace MLAPI.Editor.CodeGen
+{
+    internal class AssemblyDefinition
+    {
+        public string name = "";
+        public string[] references = new string[0];
+        public string[] optionalUnityReferences = new string[0];
+        public string[] includePlatforms = new string[0];
+        public string[] excludePlatforms = new string[0];
+        public string[] precompiledReferences = new string[0];
+    }
+
+    public abstract class ILPostProcessor
+    {
+        public virtual bool WillProcess(ICompiledAssembly compiledAssembly) => false;
+        public virtual ILPostProcessResult Process(ICompiledAssembly compiledAssembly) => null;
+        public virtual ILPostProcessor GetInstance() => null;
+    }
+}
+
+#endif

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs.meta
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbffd9b273517da4a9c4a3218771e0b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
@@ -1,217 +1,216 @@
-#if !USE_UNITY_ILPP
-
+#if !UNITY_2020_2_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.IO;
-
-using MLAPI.Editor.CodeGen;
-
+using System.Linq;
 using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
+
 using Assembly = System.Reflection.Assembly;
-using ILPostProcessor = MLAPI.Editor.CodeGen.ILPostProcessor;
 
-internal class ILPostProcessProgram
+namespace MLAPI.Editor.CodeGen
 {
-    public static ILPostProcessor[] ILPostProcessors { get; set; }
-
-    [InitializeOnLoadMethod]
-    static void OnInitializeOnLoad()
+    internal static class ILPostProcessProgram
     {
-        CompilationPipeline.assemblyCompilationFinished += OnCompilationFinished;
-        ILPostProcessors = FindAllPostProcessors();
-    }
+        private static ILPostProcessor[] ILPostProcessors { get; set; }
 
-    public static ILPostProcessor[] FindAllPostProcessors()
-    {
-        TypeCache.TypeCollection typesDerivedFrom = TypeCache.GetTypesDerivedFrom<ILPostProcessor>();
-        var localILPostProcessors = new List<ILPostProcessor>(typesDerivedFrom.Count);
-
-        for (int i = 0; i < typesDerivedFrom.Count; i++)
+        [InitializeOnLoadMethod]
+        private static void OnInitializeOnLoad()
         {
-            try
-            {
-                localILPostProcessors.Add((ILPostProcessor)Activator.CreateInstance(typesDerivedFrom[i]));
-            }
-            catch (Exception exception)
-            {
-                Console.WriteLine($"Could not create ILPostProcessor ({typesDerivedFrom[i].FullName}):{Environment.NewLine}{exception.StackTrace}");
-            }
+            CompilationPipeline.assemblyCompilationFinished += OnCompilationFinished;
+            ILPostProcessors = FindAllPostProcessors();
         }
 
-        // Default sort by type full name
-        localILPostProcessors.Sort((left, right) => string.Compare(left.GetType().FullName, right.GetType().FullName, StringComparison.Ordinal));
-
-        return localILPostProcessors.ToArray();
-    }
-
-    internal static void OnCompilationFinished(string targetAssembly, CompilerMessage[] messages)
-    {
-        if (messages.Length > 0)
+        private static ILPostProcessor[] FindAllPostProcessors()
         {
-            foreach (var msg in messages)
+            var typesDerivedFrom = TypeCache.GetTypesDerivedFrom<ILPostProcessor>();
+            var localILPostProcessors = new List<ILPostProcessor>(typesDerivedFrom.Count);
+
+            foreach (var typeCollection in typesDerivedFrom)
             {
-                if (msg.type == CompilerMessageType.Error)
+                try
+                {
+                    localILPostProcessors.Add((ILPostProcessor)Activator.CreateInstance(typeCollection));
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogError($"Could not create ILPostProcessor ({typeCollection.FullName}):{Environment.NewLine}{exception.StackTrace}");
+                }
+            }
+
+            // Default sort by type full name
+            localILPostProcessors.Sort((left, right) => string.Compare(left.GetType().FullName, right.GetType().FullName, StringComparison.Ordinal));
+
+            return localILPostProcessors.ToArray();
+        }
+
+        private static void OnCompilationFinished(string targetAssembly, CompilerMessage[] messages)
+        {
+            if (messages.Length > 0)
+            {
+                if (messages.Any(msg => msg.type == CompilerMessageType.Error))
                 {
                     return;
                 }
             }
-        }
 
-        // Should not run on the editor only assemblies
-        if (targetAssembly.Contains("-Editor") || targetAssembly.Contains(".Editor"))
-        {
-            return;
-        }
-
-        // Should not run on Unity Engine modules but we can run on the MLAPI Runtime DLL 
-        if ((targetAssembly.Contains("com.unity") || Path.GetFileName(targetAssembly).StartsWith("Unity")) && !targetAssembly.Contains("Unity.Multiplayer."))
-        {
-            return;
-        }
-
-        var scriptAssembliesPath = Application.dataPath + "/../" + Path.GetDirectoryName(targetAssembly);
-
-#if MLAPI_ILPP_LOGGING
-        Debug.Log($"Running MLAPI ILPP on {targetAssembly}");
-#endif
-
-        var outputDirectory = scriptAssembliesPath;
-        var assemblyPath = targetAssembly;
-        string unityEngine = "";
-        string mlapiRuntimeAssemblyPath = "";
-
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-        bool usesMLAPI = false;
-        bool foundThisAssembly = false;
-
-        List<string> depenencyPaths = new List<string>();
-        foreach (var assembly in assemblies)
-        {
-            // Find the assembly currently being compiled from domain assembly list and check if it's using unet
-            if (assembly.GetName().Name == Path.GetFileNameWithoutExtension(targetAssembly))
+            // Should not run on the editor only assemblies
+            if (targetAssembly.Contains("-Editor") || targetAssembly.Contains(".Editor"))
             {
-                foundThisAssembly = true;
-                foreach (var dependency in assembly.GetReferencedAssemblies())
-                {
-                    // Since this assembly is already loaded in the domain this is a no-op and returns the
-                    // already loaded assembly
-                    var location = Assembly.Load(dependency).Location;
-                    depenencyPaths.Add(Path.GetFileNameWithoutExtension(location));
-                    if (dependency.Name.Contains(CodeGenHelpers.RuntimeAssemblyName))
-                    {
-                        usesMLAPI = true;
-                    }
-                }
+                return;
             }
-            try
-            {
-                if (assembly.Location.Contains("UnityEngine.CoreModule"))
-                {
-                    unityEngine = assembly.Location;
-                }
-                if (assembly.Location.Contains(CodeGenHelpers.RuntimeAssemblyName))
-                {
-                    mlapiRuntimeAssemblyPath = assembly.Location;
-                }
-            }
-            catch (NotSupportedException)
-            {
-                // in memory assembly, can't get location
-            }
-        }
 
-        if (!foundThisAssembly)
-        {
-            // Target assembly not found in current domain, trying to load it to check references 
-            // will lead to trouble in the build pipeline, so lets assume it should go to weaver.
-            // Add all assemblies in current domain to dependency list since there could be a 
-            // dependency lurking there (there might be generated assemblies so ignore file not found exceptions).
-            // (can happen in runtime test framework on editor platform and when doing full library reimport)
+            // Should not run on Unity Engine modules but we can run on the MLAPI Runtime DLL 
+            if ((targetAssembly.Contains("com.unity") || Path.GetFileName(targetAssembly).StartsWith("Unity")) && !targetAssembly.Contains("Unity.Multiplayer."))
+            {
+                return;
+            }
+
+            // Debug.Log($"Running MLAPI ILPP on {targetAssembly}");
+
+            var outputDirectory = $"{Application.dataPath}/../{Path.GetDirectoryName(targetAssembly)}";
+            var unityEngine = string.Empty;
+            var mlapiRuntimeAssemblyPath = string.Empty;
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var usesMLAPI = false;
+            var foundThisAssembly = false;
+
+            var depenencyPaths = new List<string>();
             foreach (var assembly in assemblies)
             {
-                try
+                // Find the assembly currently being compiled from domain assembly list and check if it's using unet
+                if (assembly.GetName().Name == Path.GetFileNameWithoutExtension(targetAssembly))
                 {
-                    if (!(assembly.ManifestModule is System.Reflection.Emit.ModuleBuilder))
+                    foundThisAssembly = true;
+                    foreach (var dependency in assembly.GetReferencedAssemblies())
                     {
-                        var location = Assembly.Load(assembly.GetName().Name).Location;
-                        if (!string.IsNullOrEmpty(location))
-                            depenencyPaths.Add(Path.GetFileNameWithoutExtension(location));
+                        // Since this assembly is already loaded in the domain this is a no-op and returns the
+                        // already loaded assembly
+                        depenencyPaths.Add(Assembly.Load(dependency).Location);
+                        if (dependency.Name.Contains(CodeGenHelpers.RuntimeAssemblyName))
+                        {
+                            usesMLAPI = true;
+                        }
                     }
                 }
-                catch (FileNotFoundException) { }
-            }
-            usesMLAPI = true;
-        }
 
-        // We check if we are the MLAPI!
-        if (!usesMLAPI)
-        {
-            // we shall also check and see if it we are ourself
-            usesMLAPI = targetAssembly.Contains(CodeGenHelpers.RuntimeAssemblyName);
-        }
-
-        if (!usesMLAPI)
-        {
-            return;
-        }
-
-        if (string.IsNullOrEmpty(unityEngine))
-        {
-            Debug.LogError("Failed to find UnityEngine assembly");
-            return;
-        }
-
-        if (string.IsNullOrEmpty(mlapiRuntimeAssemblyPath))
-        {
-            Debug.LogError("Failed to find mlapi runtime assembly");
-            return;
-        }
-
-        var assemblyPathName = Path.GetFileName(targetAssembly);
-
-        var targetCompiledAssembly = new ILPostProcessCompiledAssembly(assemblyPathName, depenencyPaths.ToArray() , null, outputDirectory);
-
-        void WriteAssembly(InMemoryAssembly inMemoryAssembly, string outputPath, string assName)
-        {
-            if (inMemoryAssembly == null)
-            {
-                throw new ArgumentException("InMemoryAssembly has never been accessed or modified");
-            }
-
-            var assPath = Path.Combine(outputPath, assName);
-            var pdbFileName = Path.GetFileNameWithoutExtension(assName) + ".pdb";
-            var pdbPath = Path.Combine(outputPath, pdbFileName);
-
-            File.WriteAllBytes(assPath, inMemoryAssembly.PeData);
-            File.WriteAllBytes(pdbPath, inMemoryAssembly.PdbData);
-        }
-
-        foreach (var i in ILPostProcessors)
-        {
-            var result = i.Process(targetCompiledAssembly);
-            if (result == null)
-                continue;
-
-            if (result.Diagnostics.Count > 0)
-            {
-                Type type = i.GetType();
-                Debug.LogError($"ILPostProcessor - {nameof(type)} failed to run on {targetCompiledAssembly.Name}");
-
-                foreach (var message in result.Diagnostics)
+                try
                 {
-                    if (message.DiagnosticType == DiagnosticType.Error)
-                        Debug.LogError($"ILPostProcessor Error - {message.MessageData} {message.File} {message.Line} {message.Column}");
-                    if (message.DiagnosticType == DiagnosticType.Warning)
-                        Debug.LogWarning($"ILPostProcessor Warning - {message.MessageData} {message.File} {message.Line} {message.Column}");
+                    if (assembly.Location.Contains("UnityEngine.CoreModule"))
+                    {
+                        unityEngine = assembly.Location;
+                    }
+
+                    if (assembly.Location.Contains(CodeGenHelpers.RuntimeAssemblyName))
+                    {
+                        mlapiRuntimeAssemblyPath = assembly.Location;
+                    }
                 }
-                continue;
+                catch (NotSupportedException)
+                {
+                    // in memory assembly, can't get location
+                }
             }
-            // we now need to write out the result?
-            WriteAssembly(result.InMemoryAssembly, outputDirectory, assemblyPathName);
+
+            if (!foundThisAssembly)
+            {
+                // Target assembly not found in current domain, trying to load it to check references 
+                // will lead to trouble in the build pipeline, so lets assume it should go to weaver.
+                // Add all assemblies in current domain to dependency list since there could be a 
+                // dependency lurking there (there might be generated assemblies so ignore file not found exceptions).
+                // (can happen in runtime test framework on editor platform and when doing full library reimport)
+                foreach (var assembly in assemblies)
+                {
+                    try
+                    {
+                        if (!(assembly.ManifestModule is System.Reflection.Emit.ModuleBuilder))
+                        {
+                            depenencyPaths.Add(Assembly.Load(assembly.GetName().Name).Location);
+                        }
+                    }
+                    catch (FileNotFoundException)
+                    {
+                    }
+                }
+
+                usesMLAPI = true;
+            }
+
+            // We check if we are the MLAPI!
+            if (!usesMLAPI)
+            {
+                // we shall also check and see if it we are ourself
+                usesMLAPI = targetAssembly.Contains(CodeGenHelpers.RuntimeAssemblyName);
+            }
+
+            if (!usesMLAPI)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(unityEngine))
+            {
+                Debug.LogError("Failed to find UnityEngine assembly");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(mlapiRuntimeAssemblyPath))
+            {
+                Debug.LogError("Failed to find mlapi runtime assembly");
+                return;
+            }
+
+            var assemblyPathName = Path.GetFileName(targetAssembly);
+
+            var targetCompiledAssembly = new ILPostProcessCompiledAssembly(assemblyPathName, depenencyPaths.ToArray(), null, outputDirectory);
+
+            void WriteAssembly(InMemoryAssembly inMemoryAssembly, string outputPath, string assName)
+            {
+                if (inMemoryAssembly == null)
+                {
+                    throw new ArgumentException("InMemoryAssembly has never been accessed or modified");
+                }
+
+                var asmPath = Path.Combine(outputPath, assName);
+                var pdbFileName = $"{Path.GetFileNameWithoutExtension(assName)}.pdb";
+                var pdbPath = Path.Combine(outputPath, pdbFileName);
+
+                File.WriteAllBytes(asmPath, inMemoryAssembly.PeData);
+                File.WriteAllBytes(pdbPath, inMemoryAssembly.PdbData);
+            }
+
+            foreach (var i in ILPostProcessors)
+            {
+                var result = i.Process(targetCompiledAssembly);
+                if (result == null)
+                    continue;
+
+                if (result.Diagnostics.Count > 0)
+                {
+                    Debug.LogError($"ILPostProcessor - {i.GetType().Name} failed to run on {targetCompiledAssembly.Name}");
+
+                    foreach (var message in result.Diagnostics)
+                    {
+                        switch (message.DiagnosticType)
+                        {
+                            case DiagnosticType.Error:
+                                Debug.LogError($"ILPostProcessor Error - {message.MessageData} {message.File} {message.Line} {message.Column}");
+                                break;
+                            case DiagnosticType.Warning:
+                                Debug.LogWarning($"ILPostProcessor Warning - {message.MessageData} {message.File} {message.Line} {message.Column}");
+                                break;
+                        }
+                    }
+
+                    continue;
+                }
+
+                // we now need to write out the result?
+                WriteAssembly(result.InMemoryAssembly, outputDirectory, assemblyPathName);
+            }
         }
     }
 }

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
@@ -1,4 +1,4 @@
-#if !UNITY_2020_2_OR_NEWER || UNITY_2021_1_OR_NEWER
+#if !UNITY_2020_2_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,13 +15,13 @@ namespace MLAPI.Editor.CodeGen
 {
     internal static class ILPostProcessProgram
     {
-        private static ILPostProcessor[] ILPostProcessors { get; set; }
+        private static ILPostProcessor[] s_ILPostProcessors { get; set; }
 
         [InitializeOnLoadMethod]
         private static void OnInitializeOnLoad()
         {
             CompilationPipeline.assemblyCompilationFinished += OnCompilationFinished;
-            ILPostProcessors = FindAllPostProcessors();
+            s_ILPostProcessors = FindAllPostProcessors();
         }
 
         private static ILPostProcessor[] FindAllPostProcessors()
@@ -182,7 +182,7 @@ namespace MLAPI.Editor.CodeGen
                 File.WriteAllBytes(pdbPath, inMemoryAssembly.PdbData);
             }
 
-            foreach (var i in ILPostProcessors)
+            foreach (var i in s_ILPostProcessors)
             {
                 var result = i.Process(targetCompiledAssembly);
                 if (result == null)

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
@@ -1,4 +1,4 @@
-#if !UNITY_2020_2_OR_NEWER
+#if !UNITY_2020_2_OR_NEWER || UNITY_2021_1_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs.meta
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72c7d2bd3d748db4d988e2204fe1083e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -13,7 +13,7 @@ using Unity.CompilationPipeline.Common.ILPostProcessing;
 using MethodAttributes = Mono.Cecil.MethodAttributes;
 using ParameterAttributes = Mono.Cecil.ParameterAttributes;
 
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
 using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostProcessor;
 #else
 using ILPPInterface = MLAPI.Editor.CodeGen.ILPostProcessor;
@@ -150,6 +150,7 @@ namespace MLAPI.Editor.CodeGen
         private const string NetworkingManager_IsHost = nameof(NetworkingManager.IsHost);
         private const string NetworkingManager_IsServer = nameof(NetworkingManager.IsServer);
         private const string NetworkingManager_IsClient = nameof(NetworkingManager.IsClient);
+#pragma warning disable 618
         private const string NetworkingManager_ntable = nameof(NetworkingManager.__ntable);
 
         private const string NetworkedBehaviour_BeginSendServerRpc = nameof(NetworkedBehaviour.__beginSendServerRpc);
@@ -157,6 +158,7 @@ namespace MLAPI.Editor.CodeGen
         private const string NetworkedBehaviour_BeginSendClientRpc = nameof(NetworkedBehaviour.__beginSendClientRpc);
         private const string NetworkedBehaviour_EndSendClientRpc = nameof(NetworkedBehaviour.__endSendClientRpc);
         private const string NetworkedBehaviour_nexec = nameof(NetworkedBehaviour.__nexec);
+#pragma warning restore 618
 
         private bool ImportReferences(ModuleDefinition moduleDefinition)
         {
@@ -630,7 +632,9 @@ namespace MLAPI.Editor.CodeGen
                 // if (__nexec != NExec.Client) -> ClientRpc
                 instructions.Add(processor.Create(OpCodes.Ldarg_0));
                 instructions.Add(processor.Create(OpCodes.Ldfld, NetworkBehaviour_nexec_FieldRef));
+#pragma warning disable 618
                 instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.__NExec.Server : NetworkedBehaviour.__NExec.Client)));
+#pragma warning restore 618
                 instructions.Add(processor.Create(OpCodes.Ceq));
                 instructions.Add(processor.Create(OpCodes.Ldc_I4, 0));
                 instructions.Add(processor.Create(OpCodes.Ceq));
@@ -995,7 +999,9 @@ namespace MLAPI.Editor.CodeGen
                 // if (__nexec == NExec.Client) -> ClientRpc
                 instructions.Add(processor.Create(OpCodes.Ldarg_0));
                 instructions.Add(processor.Create(OpCodes.Ldfld, NetworkBehaviour_nexec_FieldRef));
+#pragma warning disable 618
                 instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.__NExec.Server : NetworkedBehaviour.__NExec.Client)));
+#pragma warning restore 618
                 instructions.Add(processor.Create(OpCodes.Ceq));
                 instructions.Add(processor.Create(OpCodes.Brfalse, returnInstr));
 
@@ -1280,7 +1286,9 @@ namespace MLAPI.Editor.CodeGen
             // NetworkBehaviour.__nexec = NExec.Server; -> ServerRpc
             // NetworkBehaviour.__nexec = NExec.Client; -> ClientRpc
             processor.Emit(OpCodes.Ldarg_0);
+#pragma warning disable 618
             processor.Emit(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.__NExec.Server : NetworkedBehaviour.__NExec.Client));
+#pragma warning restore 618
             processor.Emit(OpCodes.Stfld, NetworkBehaviour_nexec_FieldRef);
 
             // NetworkBehaviour.XXXRpc(...);
@@ -1291,7 +1299,9 @@ namespace MLAPI.Editor.CodeGen
 
             // NetworkBehaviour.__nexec = NExec.None;
             processor.Emit(OpCodes.Ldarg_0);
+#pragma warning disable 618
             processor.Emit(OpCodes.Ldc_I4, (int)NetworkedBehaviour.__NExec.None);
+#pragma warning restore 618
             processor.Emit(OpCodes.Stfld, NetworkBehaviour_nexec_FieldRef);
 
             processor.Emit(OpCodes.Ret);

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -152,10 +152,10 @@ namespace MLAPI.Editor.CodeGen
         private const string NetworkingManager_IsClient = nameof(NetworkingManager.IsClient);
         private const string NetworkingManager_ntable = nameof(NetworkingManager.__ntable);
 
-        private const string NetworkedBehaviour_BeginSendServerRpc = nameof(NetworkedBehaviour.BeginSendServerRpc);
-        private const string NetworkedBehaviour_EndSendServerRpc = nameof(NetworkedBehaviour.EndSendServerRpc);
-        private const string NetworkedBehaviour_BeginSendClientRpc = nameof(NetworkedBehaviour.BeginSendClientRpc);
-        private const string NetworkedBehaviour_EndSendClientRpc = nameof(NetworkedBehaviour.EndSendClientRpc);
+        private const string NetworkedBehaviour_BeginSendServerRpc = nameof(NetworkedBehaviour.__beginSendServerRpc);
+        private const string NetworkedBehaviour_EndSendServerRpc = nameof(NetworkedBehaviour.__endSendServerRpc);
+        private const string NetworkedBehaviour_BeginSendClientRpc = nameof(NetworkedBehaviour.__beginSendClientRpc);
+        private const string NetworkedBehaviour_EndSendClientRpc = nameof(NetworkedBehaviour.__endSendClientRpc);
         private const string NetworkedBehaviour_nexec = nameof(NetworkedBehaviour.__nexec);
 
         private bool ImportReferences(ModuleDefinition moduleDefinition)
@@ -630,7 +630,7 @@ namespace MLAPI.Editor.CodeGen
                 // if (__nexec != NExec.Client) -> ClientRpc
                 instructions.Add(processor.Create(OpCodes.Ldarg_0));
                 instructions.Add(processor.Create(OpCodes.Ldfld, NetworkBehaviour_nexec_FieldRef));
-                instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.NExec.Server : NetworkedBehaviour.NExec.Client)));
+                instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.__NExec.Server : NetworkedBehaviour.__NExec.Client)));
                 instructions.Add(processor.Create(OpCodes.Ceq));
                 instructions.Add(processor.Create(OpCodes.Ldc_I4, 0));
                 instructions.Add(processor.Create(OpCodes.Ceq));
@@ -995,7 +995,7 @@ namespace MLAPI.Editor.CodeGen
                 // if (__nexec == NExec.Client) -> ClientRpc
                 instructions.Add(processor.Create(OpCodes.Ldarg_0));
                 instructions.Add(processor.Create(OpCodes.Ldfld, NetworkBehaviour_nexec_FieldRef));
-                instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.NExec.Server : NetworkedBehaviour.NExec.Client)));
+                instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.__NExec.Server : NetworkedBehaviour.__NExec.Client)));
                 instructions.Add(processor.Create(OpCodes.Ceq));
                 instructions.Add(processor.Create(OpCodes.Brfalse, returnInstr));
 
@@ -1280,7 +1280,7 @@ namespace MLAPI.Editor.CodeGen
             // NetworkBehaviour.__nexec = NExec.Server; -> ServerRpc
             // NetworkBehaviour.__nexec = NExec.Client; -> ClientRpc
             processor.Emit(OpCodes.Ldarg_0);
-            processor.Emit(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.NExec.Server : NetworkedBehaviour.NExec.Client));
+            processor.Emit(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkedBehaviour.__NExec.Server : NetworkedBehaviour.__NExec.Client));
             processor.Emit(OpCodes.Stfld, NetworkBehaviour_nexec_FieldRef);
 
             // NetworkBehaviour.XXXRpc(...);
@@ -1291,7 +1291,7 @@ namespace MLAPI.Editor.CodeGen
 
             // NetworkBehaviour.__nexec = NExec.None;
             processor.Emit(OpCodes.Ldarg_0);
-            processor.Emit(OpCodes.Ldc_I4, (int)NetworkedBehaviour.NExec.None);
+            processor.Emit(OpCodes.Ldc_I4, (int)NetworkedBehaviour.__NExec.None);
             processor.Emit(OpCodes.Stfld, NetworkBehaviour_nexec_FieldRef);
 
             processor.Emit(OpCodes.Ret);

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -13,7 +13,7 @@ using Unity.CompilationPipeline.Common.ILPostProcessing;
 using MethodAttributes = Mono.Cecil.MethodAttributes;
 using ParameterAttributes = Mono.Cecil.ParameterAttributes;
 
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
 using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostProcessor;
 #else
 using ILPPInterface = MLAPI.Editor.CodeGen.ILPostProcessor;
@@ -26,8 +26,8 @@ namespace MLAPI.Editor.CodeGen
         public override ILPPInterface GetInstance() => this;
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly) =>
-            compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName ||
-            compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == CodeGenHelpers.RuntimeAssemblyName);
+            compiledAssembly.References.Any(
+                filePath => Path.GetFileNameWithoutExtension(filePath) == CodeGenHelpers.RuntimeAssemblyName);
 
         private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 
@@ -145,19 +145,19 @@ namespace MLAPI.Editor.CodeGen
         private MethodReference BitReader_ReadRayPacked_MethodRef;
         private MethodReference BitReader_ReadRay2DPacked_MethodRef;
 
-        private const string NetworkingManager_Singleton = nameof(NetworkingManager.Singleton);
-        private const string NetworkingManager_IsListening = nameof(NetworkingManager.IsListening);
-        private const string NetworkingManager_IsHost = nameof(NetworkingManager.IsHost);
-        private const string NetworkingManager_IsServer = nameof(NetworkingManager.IsServer);
-        private const string NetworkingManager_IsClient = nameof(NetworkingManager.IsClient);
+        private const string k_NetworkingManager_Singleton = nameof(NetworkingManager.Singleton);
+        private const string k_NetworkingManager_IsListening = nameof(NetworkingManager.IsListening);
+        private const string k_NetworkingManager_IsHost = nameof(NetworkingManager.IsHost);
+        private const string k_NetworkingManager_IsServer = nameof(NetworkingManager.IsServer);
+        private const string k_NetworkingManager_IsClient = nameof(NetworkingManager.IsClient);
 #pragma warning disable 618
-        private const string NetworkingManager_ntable = nameof(NetworkingManager.__ntable);
+        private const string k_NetworkingManager_ntable = nameof(NetworkingManager.__ntable);
 
-        private const string NetworkedBehaviour_BeginSendServerRpc = nameof(NetworkedBehaviour.__beginSendServerRpc);
-        private const string NetworkedBehaviour_EndSendServerRpc = nameof(NetworkedBehaviour.__endSendServerRpc);
-        private const string NetworkedBehaviour_BeginSendClientRpc = nameof(NetworkedBehaviour.__beginSendClientRpc);
-        private const string NetworkedBehaviour_EndSendClientRpc = nameof(NetworkedBehaviour.__endSendClientRpc);
-        private const string NetworkedBehaviour_nexec = nameof(NetworkedBehaviour.__nexec);
+        private const string k_NetworkedBehaviour_BeginSendServerRpc = nameof(NetworkedBehaviour.__beginSendServerRpc);
+        private const string k_NetworkedBehaviour_EndSendServerRpc = nameof(NetworkedBehaviour.__endSendServerRpc);
+        private const string k_NetworkedBehaviour_BeginSendClientRpc = nameof(NetworkedBehaviour.__beginSendClientRpc);
+        private const string k_NetworkedBehaviour_EndSendClientRpc = nameof(NetworkedBehaviour.__endSendClientRpc);
+        private const string k_NetworkedBehaviour_nexec = nameof(NetworkedBehaviour.__nexec);
 #pragma warning restore 618
 
         private bool ImportReferences(ModuleDefinition moduleDefinition)
@@ -168,19 +168,19 @@ namespace MLAPI.Editor.CodeGen
             {
                 switch (propertyInfo.Name)
                 {
-                    case NetworkingManager_Singleton:
+                    case k_NetworkingManager_Singleton:
                         NetworkManager_getSingleton_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
                         break;
-                    case NetworkingManager_IsListening:
+                    case k_NetworkingManager_IsListening:
                         NetworkManager_getIsListening_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
                         break;
-                    case NetworkingManager_IsHost:
+                    case k_NetworkingManager_IsHost:
                         NetworkManager_getIsHost_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
                         break;
-                    case NetworkingManager_IsServer:
+                    case k_NetworkingManager_IsServer:
                         NetworkManager_getIsServer_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
                         break;
-                    case NetworkingManager_IsClient:
+                    case k_NetworkingManager_IsClient:
                         NetworkManager_getIsClient_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
                         break;
                 }
@@ -190,7 +190,7 @@ namespace MLAPI.Editor.CodeGen
             {
                 switch (fieldInfo.Name)
                 {
-                    case NetworkingManager_ntable:
+                    case k_NetworkingManager_ntable:
                         NetworkManager_ntable_FieldRef = moduleDefinition.ImportReference(fieldInfo);
                         NetworkManager_ntable_Add_MethodRef = moduleDefinition.ImportReference(fieldInfo.FieldType.GetMethod("Add"));
                         break;
@@ -203,16 +203,16 @@ namespace MLAPI.Editor.CodeGen
             {
                 switch (methodInfo.Name)
                 {
-                    case NetworkedBehaviour_BeginSendServerRpc:
+                    case k_NetworkedBehaviour_BeginSendServerRpc:
                         NetworkBehaviour_BeginSendServerRpc_MethodRef = moduleDefinition.ImportReference(methodInfo);
                         break;
-                    case NetworkedBehaviour_EndSendServerRpc:
+                    case k_NetworkedBehaviour_EndSendServerRpc:
                         NetworkBehaviour_EndSendServerRpc_MethodRef = moduleDefinition.ImportReference(methodInfo);
                         break;
-                    case NetworkedBehaviour_BeginSendClientRpc:
+                    case k_NetworkedBehaviour_BeginSendClientRpc:
                         NetworkBehaviour_BeginSendClientRpc_MethodRef = moduleDefinition.ImportReference(methodInfo);
                         break;
-                    case NetworkedBehaviour_EndSendClientRpc:
+                    case k_NetworkedBehaviour_EndSendClientRpc:
                         NetworkBehaviour_EndSendClientRpc_MethodRef = moduleDefinition.ImportReference(methodInfo);
                         break;
                 }
@@ -222,7 +222,7 @@ namespace MLAPI.Editor.CodeGen
             {
                 switch (fieldInfo.Name)
                 {
-                    case NetworkedBehaviour_nexec:
+                    case k_NetworkedBehaviour_nexec:
                         NetworkBehaviour_nexec_FieldRef = moduleDefinition.ImportReference(fieldInfo);
                         break;
                 }

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/PostProcessorAssemblyResolver.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/PostProcessorAssemblyResolver.cs
@@ -6,71 +6,77 @@ using System.Threading;
 using Mono.Cecil;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 
-using AssemblyDefinition = Mono.Cecil.AssemblyDefinition;
-
 namespace MLAPI.Editor.CodeGen
 {
-    class PostProcessorAssemblyResolver : IAssemblyResolver
+    internal class PostProcessorAssemblyResolver : IAssemblyResolver
     {
-        private readonly string[] _assemblyReferences;
-        private readonly Dictionary<string, Mono.Cecil.AssemblyDefinition> _assemblyCache = new Dictionary<string, Mono.Cecil.AssemblyDefinition>();
-        private readonly ICompiledAssembly _compiledAssembly;
-        private Mono.Cecil.AssemblyDefinition _selfAssembly;
+        private readonly string[] m_AssemblyReferences;
+        private readonly Dictionary<string, AssemblyDefinition> m_AssemblyCache = new Dictionary<string, AssemblyDefinition>();
+        private readonly ICompiledAssembly m_CompiledAssembly;
+        private AssemblyDefinition m_SelfAssembly;
 
         public PostProcessorAssemblyResolver(ICompiledAssembly compiledAssembly)
         {
-            _compiledAssembly = compiledAssembly;
-            _assemblyReferences = compiledAssembly.References;
+            m_CompiledAssembly = compiledAssembly;
+            m_AssemblyReferences = compiledAssembly.References;
         }
 
-        public void Dispose()
-        {
-        }
+        public void Dispose() { }
 
-        public Mono.Cecil.AssemblyDefinition Resolve(AssemblyNameReference name) => Resolve(name, new ReaderParameters(ReadingMode.Deferred));
+        public AssemblyDefinition Resolve(AssemblyNameReference name) => Resolve(name, new ReaderParameters(ReadingMode.Deferred));
 
-        public Mono.Cecil.AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
         {
-            lock (_assemblyCache)
+            lock (m_AssemblyCache)
             {
-                if (name.Name == _compiledAssembly.Name)
-                    return _selfAssembly;
+                if (name.Name == m_CompiledAssembly.Name)
+                {
+                    return m_SelfAssembly;
+                }
 
                 var fileName = FindFile(name);
                 if (fileName == null)
+                {
                     return null;
+                }
 
                 var lastWriteTime = File.GetLastWriteTime(fileName);
-
-                var cacheKey = fileName + lastWriteTime;
-
-                if (_assemblyCache.TryGetValue(cacheKey, out var result))
+                var cacheKey = $"{fileName}{lastWriteTime}";
+                if (m_AssemblyCache.TryGetValue(cacheKey, out var result))
+                {
                     return result;
+                }
 
                 parameters.AssemblyResolver = this;
 
                 var ms = MemoryStreamFor(fileName);
-
-                var pdb = fileName + ".pdb";
+                var pdb = $"{fileName}.pdb";
                 if (File.Exists(pdb))
+                {
                     parameters.SymbolStream = MemoryStreamFor(pdb);
+                }
 
-                var assemblyDefinition = Mono.Cecil.AssemblyDefinition.ReadAssembly(ms, parameters);
-                _assemblyCache.Add(cacheKey, assemblyDefinition);
+                var assemblyDefinition = AssemblyDefinition.ReadAssembly(ms, parameters);
+                m_AssemblyCache.Add(cacheKey, assemblyDefinition);
+
                 return assemblyDefinition;
             }
         }
 
         private string FindFile(AssemblyNameReference name)
         {
-            var fileName = _assemblyReferences.FirstOrDefault(r => Path.GetFileName(r) == name.Name + ".dll");
+            var fileName = m_AssemblyReferences.FirstOrDefault(r => Path.GetFileName(r) == $"{name.Name}.dll");
             if (fileName != null)
+            {
                 return fileName;
+            }
 
             // perhaps the type comes from an exe instead
-            fileName = _assemblyReferences.FirstOrDefault(r => Path.GetFileName(r) == name.Name + ".exe");
+            fileName = m_AssemblyReferences.FirstOrDefault(r => Path.GetFileName(r) == $"{name.Name}.exe");
             if (fileName != null)
+            {
                 return fileName;
+            }
 
             //Unfortunately the current ICompiledAssembly API only provides direct references.
             //It is very much possible that a postprocessor ends up investigating a type in a directly
@@ -79,17 +85,14 @@ namespace MLAPI.Editor.CodeGen
             //in the ILPostProcessing API. As a workaround, we rely on the fact here that the indirect references
             //are always located next to direct references, so we search in all directories of direct references we
             //got passed, and if we find the file in there, we resolve to it.
-            foreach (var parentDir in _assemblyReferences.Select(Path.GetDirectoryName).Distinct())
-            {
-                var candidate = Path.Combine(parentDir, name.Name + ".dll");
-                if (File.Exists(candidate))
-                    return candidate;
-            }
-
-            return null;
+            return m_AssemblyReferences
+                .Select(Path.GetDirectoryName)
+                .Distinct()
+                .Select(parentDir => Path.Combine(parentDir, $"{name.Name}.dll"))
+                .FirstOrDefault(File.Exists);
         }
 
-        static MemoryStream MemoryStreamFor(string fileName)
+        private static MemoryStream MemoryStreamFor(string fileName)
         {
             return Retry(10, TimeSpan.FromSeconds(1), () =>
             {
@@ -99,7 +102,9 @@ namespace MLAPI.Editor.CodeGen
                     byteArray = new byte[fs.Length];
                     var readLength = fs.Read(byteArray, 0, (int)fs.Length);
                     if (readLength != fs.Length)
+                    {
                         throw new InvalidOperationException("File read length is not full length of file.");
+                    }
                 }
 
                 return new MemoryStream(byteArray);
@@ -115,16 +120,20 @@ namespace MLAPI.Editor.CodeGen
             catch (IOException)
             {
                 if (retryCount == 0)
+                {
                     throw;
+                }
+
                 Console.WriteLine($"Caught IO Exception, trying {retryCount} more times");
                 Thread.Sleep(waitTime);
+
                 return Retry(retryCount - 1, waitTime, func);
             }
         }
 
-        public void AddAssemblyDefinitionBeingOperatedOn(Mono.Cecil.AssemblyDefinition assemblyDefinition)
+        public void AddAssemblyDefinitionBeingOperatedOn(AssemblyDefinition assemblyDefinition)
         {
-            _selfAssembly = assemblyDefinition;
+            m_SelfAssembly = assemblyDefinition;
         }
     }
 }

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/PostProcessorAssemblyResolver.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/PostProcessorAssemblyResolver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,14 +6,16 @@ using System.Threading;
 using Mono.Cecil;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 
+using AssemblyDefinition = Mono.Cecil.AssemblyDefinition;
+
 namespace MLAPI.Editor.CodeGen
 {
     class PostProcessorAssemblyResolver : IAssemblyResolver
     {
         private readonly string[] _assemblyReferences;
-        private readonly Dictionary<string, AssemblyDefinition> _assemblyCache = new Dictionary<string, AssemblyDefinition>();
+        private readonly Dictionary<string, Mono.Cecil.AssemblyDefinition> _assemblyCache = new Dictionary<string, Mono.Cecil.AssemblyDefinition>();
         private readonly ICompiledAssembly _compiledAssembly;
-        private AssemblyDefinition _selfAssembly;
+        private Mono.Cecil.AssemblyDefinition _selfAssembly;
 
         public PostProcessorAssemblyResolver(ICompiledAssembly compiledAssembly)
         {
@@ -25,9 +27,9 @@ namespace MLAPI.Editor.CodeGen
         {
         }
 
-        public AssemblyDefinition Resolve(AssemblyNameReference name) => Resolve(name, new ReaderParameters(ReadingMode.Deferred));
+        public Mono.Cecil.AssemblyDefinition Resolve(AssemblyNameReference name) => Resolve(name, new ReaderParameters(ReadingMode.Deferred));
 
-        public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        public Mono.Cecil.AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
         {
             lock (_assemblyCache)
             {
@@ -53,7 +55,7 @@ namespace MLAPI.Editor.CodeGen
                 if (File.Exists(pdb))
                     parameters.SymbolStream = MemoryStreamFor(pdb);
 
-                var assemblyDefinition = AssemblyDefinition.ReadAssembly(ms, parameters);
+                var assemblyDefinition = Mono.Cecil.AssemblyDefinition.ReadAssembly(ms, parameters);
                 _assemblyCache.Add(cacheKey, assemblyDefinition);
                 return assemblyDefinition;
             }
@@ -120,7 +122,7 @@ namespace MLAPI.Editor.CodeGen
             }
         }
 
-        public void AddAssemblyDefinitionBeingOperatedOn(AssemblyDefinition assemblyDefinition)
+        public void AddAssemblyDefinitionBeingOperatedOn(Mono.Cecil.AssemblyDefinition assemblyDefinition)
         {
             _selfAssembly = assemblyDefinition;
         }

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/PostProcessorReflectionImporter.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/PostProcessorReflectionImporter.cs
@@ -7,16 +7,16 @@ namespace MLAPI.Editor.CodeGen
     internal class PostProcessorReflectionImporter : DefaultReflectionImporter
     {
         private const string SystemPrivateCoreLib = "System.Private.CoreLib";
-        private readonly AssemblyNameReference _correctCorlib;
+        private readonly AssemblyNameReference m_CorrectCorlib;
 
         public PostProcessorReflectionImporter(ModuleDefinition module) : base(module)
         {
-            _correctCorlib = module.AssemblyReferences.FirstOrDefault(a => a.Name == "mscorlib" || a.Name == "netstandard" || a.Name == SystemPrivateCoreLib);
+            m_CorrectCorlib = module.AssemblyReferences.FirstOrDefault(a => a.Name == "mscorlib" || a.Name == "netstandard" || a.Name == SystemPrivateCoreLib);
         }
 
         public override AssemblyNameReference ImportReference(AssemblyName reference)
         {
-            return _correctCorlib != null && reference.Name == SystemPrivateCoreLib ? _correctCorlib : base.ImportReference(reference);
+            return m_CorrectCorlib != null && reference.Name == SystemPrivateCoreLib ? m_CorrectCorlib : base.ImportReference(reference);
         }
     }
 }

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/PostProcessorReflectionImporterProvider.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/PostProcessorReflectionImporterProvider.cs
@@ -4,9 +4,9 @@ namespace MLAPI.Editor.CodeGen
 {
     internal class PostProcessorReflectionImporterProvider : IReflectionImporterProvider
     {
-        public IReflectionImporter GetReflectionImporter(ModuleDefinition module)
+        public IReflectionImporter GetReflectionImporter(ModuleDefinition moduleDefinition)
         {
-            return new PostProcessorReflectionImporter(module);
+            return new PostProcessorReflectionImporter(moduleDefinition);
         }
     }
 }

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -1,4 +1,4 @@
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
 using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -1,3 +1,6 @@
+
+#if MLAPI_RUNTIME_ILPP
+
 using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;
@@ -5,11 +8,17 @@ using Mono.Cecil.Cil;
 using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 
+#if !USE_UNITY_ILPP
+using ILPPInterface = MLAPI.Editor.CodeGen.ILPostProcessor;
+#else
+using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostProcessor;
+#endif
+
 namespace MLAPI.Editor.CodeGen
 {
-    internal sealed class RuntimeAccessModifiersILPP : ILPostProcessor
+    internal sealed class RuntimeAccessModifiersILPP : ILPPInterface
     {
-        public override ILPostProcessor GetInstance() => this;
+        public override ILPPInterface GetInstance() => this;
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
 

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -1,6 +1,4 @@
-
-#if MLAPI_RUNTIME_ILPP
-
+#if UNITY_2020_2_OR_NEWER
 using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;
@@ -8,11 +6,7 @@ using Mono.Cecil.Cil;
 using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 
-#if !USE_UNITY_ILPP
-using ILPPInterface = MLAPI.Editor.CodeGen.ILPostProcessor;
-#else
 using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostProcessor;
-#endif
 
 namespace MLAPI.Editor.CodeGen
 {
@@ -22,18 +16,18 @@ namespace MLAPI.Editor.CodeGen
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
 
-        private readonly List<DiagnosticMessage> _diagnostics = new List<DiagnosticMessage>();
+        private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 
         public override ILPostProcessResult Process(ICompiledAssembly compiledAssembly)
         {
             if (!WillProcess(compiledAssembly)) return null;
-            _diagnostics.Clear();
+            m_Diagnostics.Clear();
 
             // read
             var assemblyDefinition = CodeGenHelpers.AssemblyDefinitionFor(compiledAssembly);
             if (assemblyDefinition == null)
             {
-                _diagnostics.AddError($"Cannot read MLAPI Runtime assembly definition: {compiledAssembly.Name}");
+                m_Diagnostics.AddError($"Cannot read MLAPI Runtime assembly definition: {compiledAssembly.Name}");
                 return null;
             }
 
@@ -56,7 +50,7 @@ namespace MLAPI.Editor.CodeGen
                     }
                 }
             }
-            else _diagnostics.AddError($"Cannot get main module from MLAPI Runtime assembly definition: {compiledAssembly.Name}");
+            else m_Diagnostics.AddError($"Cannot get main module from MLAPI Runtime assembly definition: {compiledAssembly.Name}");
 
             // write
             var pe = new MemoryStream();
@@ -71,7 +65,7 @@ namespace MLAPI.Editor.CodeGen
 
             assemblyDefinition.Write(pe, writerParameters);
 
-            return new ILPostProcessResult(new InMemoryAssembly(pe.ToArray(), pdb.ToArray()), _diagnostics);
+            return new ILPostProcessResult(new InMemoryAssembly(pe.ToArray(), pdb.ToArray()), m_Diagnostics);
         }
 
         private void ProcessNetworkManager(TypeDefinition typeDefinition)

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -118,3 +118,4 @@ namespace MLAPI.Editor.CodeGen
         }
     }
 }
+#endif

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -83,7 +83,7 @@ namespace MLAPI.Editor.CodeGen
         {
             foreach (var nestedType in typeDefinition.NestedTypes)
             {
-                if (nestedType.Name == nameof(NetworkedBehaviour.NExec))
+                if (nestedType.Name == nameof(NetworkedBehaviour.__NExec))
                 {
                     nestedType.IsNestedFamily = true;
                 }
@@ -101,10 +101,10 @@ namespace MLAPI.Editor.CodeGen
             {
                 switch (methodDefinition.Name)
                 {
-                    case nameof(NetworkedBehaviour.BeginSendServerRpc):
-                    case nameof(NetworkedBehaviour.EndSendServerRpc):
-                    case nameof(NetworkedBehaviour.BeginSendClientRpc):
-                    case nameof(NetworkedBehaviour.EndSendClientRpc):
+                    case nameof(NetworkedBehaviour.__beginSendServerRpc):
+                    case nameof(NetworkedBehaviour.__endSendServerRpc):
+                    case nameof(NetworkedBehaviour.__beginSendClientRpc):
+                    case nameof(NetworkedBehaviour.__endSendClientRpc):
                         methodDefinition.IsFamily = true;
                         break;
                 }

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -1,4 +1,4 @@
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
 using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
@@ -19,6 +19,11 @@ using MLAPI.Transports;
 using BitStream = MLAPI.Serialization.BitStream;
 using Unity.Profiling;
 
+#if UNITY_2020_2_OR_NEWER && UNITY_EDITOR
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor.CodeGen")]
+#endif
+
 namespace MLAPI
 {
     /// <summary>
@@ -26,7 +31,12 @@ namespace MLAPI
     /// </summary>
     public abstract class NetworkedBehaviour : MonoBehaviour
     {
-        protected enum NExec
+#if UNITY_2020_2_OR_NEWER
+        // RuntimeAccessModifiersILPP will make this `protected`
+        internal enum NExec
+#else
+        public enum NExec
+#endif
         {
             None = 0,
             Server = 1,
@@ -34,10 +44,20 @@ namespace MLAPI
         }
 
 #pragma warning disable 414
-        protected NExec __nexec = NExec.None;
+#if UNITY_2020_2_OR_NEWER
+        // RuntimeAccessModifiersILPP will make this `protected`
+        internal NExec __nexec = NExec.None;
+#else
+        public NExec __nexec = NExec.None;
+#endif
 #pragma warning restore 414
 
-        protected BitWriter BeginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
+#if UNITY_2020_2_OR_NEWER
+        // RuntimeAccessModifiersILPP will make this `protected`
+        internal BitWriter BeginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
+#else
+        public BitWriter BeginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
+#endif
         {
             var rpcQueueContainer = NetworkingManager.Singleton.rpcQueueContainer;
 
@@ -66,7 +86,12 @@ namespace MLAPI
             return writer;
         }
 
-        protected void EndSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
+#if UNITY_2020_2_OR_NEWER
+        // RuntimeAccessModifiersILPP will make this `protected`
+        internal void EndSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
+#else
+        public void EndSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
+#endif
         {
             if (writer == null) return;
 
@@ -74,7 +99,12 @@ namespace MLAPI
             rpcQueueContainer.EndAddQueueItemToOutboundFrame(writer);
         }
 
-        protected BitWriter BeginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
+#if UNITY_2020_2_OR_NEWER
+        // RuntimeAccessModifiersILPP will make this `protected`
+        internal BitWriter BeginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
+#else
+        public BitWriter BeginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
+#endif
         {
             //This will start a new queue item entry and will then return the writer to the current frame's stream
             var rpcQueueContainer = NetworkingManager.Singleton.rpcQueueContainer;
@@ -91,7 +121,7 @@ namespace MLAPI
             writer.WriteUInt64Packed(NetworkId); // NetworkObjectId
             writer.WriteUInt16Packed(GetBehaviourId()); // NetworkBehaviourId
 
-                        //Write the update stage in front of RPC related information
+            //Write the update stage in front of RPC related information
             if(sendParams.UpdateStage == NetworkUpdateManager.NetworkUpdateStages.Default)
             {
                 writer.WriteUInt16Packed((ushort)NetworkUpdateManager.NetworkUpdateStages.Update);
@@ -104,7 +134,12 @@ namespace MLAPI
             return writer;
         }
 
-        protected void EndSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
+#if UNITY_2020_2_OR_NEWER
+        // RuntimeAccessModifiersILPP will make this `protected`
+        internal void EndSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
+#else
+        public void EndSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
+#endif
         {
             if (writer == null) return;
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
@@ -20,7 +20,7 @@ using MLAPI.Transports;
 using BitStream = MLAPI.Serialization.BitStream;
 using Unity.Profiling;
 
-#if UNITY_2020_2_OR_NEWER && UNITY_EDITOR
+#if UNITY_2020_2_OR_NEWER && UNITY_EDITOR && !UNITY_2021_1_OR_NEWER
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor.CodeGen")]
 #endif
@@ -34,7 +34,7 @@ namespace MLAPI
     {
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal enum __NExec
 #else
@@ -51,7 +51,7 @@ namespace MLAPI
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal __NExec __nexec = __NExec.None;
 #else
@@ -62,7 +62,7 @@ namespace MLAPI
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal BitWriter __beginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
 #else
@@ -99,7 +99,7 @@ namespace MLAPI
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal void __endSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
 #else
@@ -115,7 +115,7 @@ namespace MLAPI
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal BitWriter __beginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
 #else
@@ -153,7 +153,7 @@ namespace MLAPI
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal void __endSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
 #else

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
@@ -19,11 +19,6 @@ using MLAPI.Transports;
 using BitStream = MLAPI.Serialization.BitStream;
 using Unity.Profiling;
 
-#if UNITY_EDITOR
-using System.Runtime.CompilerServices;
-[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor.CodeGen")]
-#endif // UNITY_EDITOR
-
 namespace MLAPI
 {
     /// <summary>
@@ -31,8 +26,7 @@ namespace MLAPI
     /// </summary>
     public abstract class NetworkedBehaviour : MonoBehaviour
     {
-        // RuntimeAccessModifiersILPP will make this `protected`
-        internal enum NExec
+        protected enum NExec
         {
             None = 0,
             Server = 1,
@@ -40,12 +34,10 @@ namespace MLAPI
         }
 
 #pragma warning disable 414
-        // RuntimeAccessModifiersILPP will make this `protected`
-        internal NExec __nexec = NExec.None;
+        protected NExec __nexec = NExec.None;
 #pragma warning restore 414
 
-        // RuntimeAccessModifiersILPP will make this `protected`
-        internal BitWriter BeginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
+        protected BitWriter BeginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
         {
             var rpcQueueContainer = NetworkingManager.Singleton.rpcQueueContainer;
 
@@ -74,8 +66,7 @@ namespace MLAPI
             return writer;
         }
 
-        // RuntimeAccessModifiersILPP will make this `protected`
-        internal void EndSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
+        protected void EndSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
         {
             if (writer == null) return;
 
@@ -83,8 +74,7 @@ namespace MLAPI
             rpcQueueContainer.EndAddQueueItemToOutboundFrame(writer);
         }
 
-        // RuntimeAccessModifiersILPP will make this `protected`
-        internal BitWriter BeginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
+        protected BitWriter BeginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
         {
             //This will start a new queue item entry and will then return the writer to the current frame's stream
             var rpcQueueContainer = NetworkingManager.Singleton.rpcQueueContainer;
@@ -114,8 +104,7 @@ namespace MLAPI
             return writer;
         }
 
-        // RuntimeAccessModifiersILPP will make this `protected`
-        internal void EndSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
+        protected void EndSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
         {
             if (writer == null) return;
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using UnityEngine;
 using System.Reflection;
 using System.Linq;
@@ -31,11 +32,14 @@ namespace MLAPI
     /// </summary>
     public abstract class NetworkedBehaviour : MonoBehaviour
     {
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal enum NExec
+        internal enum __NExec
 #else
-        public enum NExec
+        [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
+        public enum __NExec
 #endif
         {
             None = 0,
@@ -44,19 +48,26 @@ namespace MLAPI
         }
 
 #pragma warning disable 414
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal NExec __nexec = NExec.None;
+        internal __NExec __nexec = __NExec.None;
 #else
-        public NExec __nexec = NExec.None;
+        [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
+        public __NExec __nexec = __NExec.None;
 #endif
 #pragma warning restore 414
 
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal BitWriter BeginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
+        internal BitWriter __beginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
 #else
-        public BitWriter BeginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
+        [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
+        public BitWriter __beginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
 #endif
         {
             var rpcQueueContainer = NetworkingManager.Singleton.rpcQueueContainer;
@@ -86,11 +97,14 @@ namespace MLAPI
             return writer;
         }
 
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal void EndSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
+        internal void __endSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
 #else
-        public void EndSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
+        [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
+        public void __endSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
 #endif
         {
             if (writer == null) return;
@@ -99,11 +113,14 @@ namespace MLAPI
             rpcQueueContainer.EndAddQueueItemToOutboundFrame(writer);
         }
 
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal BitWriter BeginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
+        internal BitWriter __beginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
 #else
-        public BitWriter BeginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
+        [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
+        public BitWriter __beginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
 #endif
         {
             //This will start a new queue item entry and will then return the writer to the current frame's stream
@@ -134,11 +151,14 @@ namespace MLAPI
             return writer;
         }
 
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal void EndSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
+        internal void __endSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
 #else
-        public void EndSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
+        [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
+        public void __endSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
 #endif
         {
             if (writer == null) return;

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
@@ -20,7 +20,7 @@ using MLAPI.Transports;
 using BitStream = MLAPI.Serialization.BitStream;
 using Unity.Profiling;
 
-#if UNITY_2020_2_OR_NEWER && UNITY_EDITOR && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && UNITY_EDITOR
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor.CodeGen")]
 #endif
@@ -34,7 +34,7 @@ namespace MLAPI
     {
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal enum __NExec
 #else
@@ -51,7 +51,7 @@ namespace MLAPI
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal __NExec __nexec = __NExec.None;
 #else
@@ -62,7 +62,7 @@ namespace MLAPI
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal BitWriter __beginSendServerRpc(ServerRpcSendParams sendParams, bool isReliable)
 #else
@@ -99,7 +99,7 @@ namespace MLAPI
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal void __endSendServerRpc(BitWriter writer, ServerRpcSendParams sendParams, bool isReliable)
 #else
@@ -115,7 +115,7 @@ namespace MLAPI
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal BitWriter __beginSendClientRpc(ClientRpcSendParams sendParams, bool isReliable)
 #else
@@ -153,7 +153,7 @@ namespace MLAPI
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
         internal void __endSendClientRpc(BitWriter writer, ClientRpcSendParams sendParams, bool isReliable)
 #else

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -28,6 +28,11 @@ using MLAPI.Transports.Tasks;
 using MLAPI.Messaging.Buffering;
 using Unity.Profiling;
 
+#if UNITY_2020_2_OR_NEWER && UNITY_EDITOR
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor.CodeGen")]
+#endif
+
 namespace MLAPI
 {
     /// <summary>
@@ -36,7 +41,12 @@ namespace MLAPI
     [AddComponentMenu("MLAPI/NetworkingManager", -100)]
     public class NetworkingManager : UpdateLoopBehaviour
     {
+#if UNITY_2020_2_OR_NEWER
+        // RuntimeAccessModifiersILPP will make this `public`
+        internal static readonly Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>> __ntable = new Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>>();
+#else
         public static readonly Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>> __ntable = new Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>>();
+#endif
 
         // @mfatihmar (Unity) Begin: Temporary, inbound RPC queue will replace this workaround
         internal readonly Queue<(ArraySegment<byte> payload, float receiveTime)> __loopbackRpcQueue = new Queue<(ArraySegment<byte> payload, float receiveTime)>();

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -45,7 +45,7 @@ namespace MLAPI
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `public`
         internal static readonly Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>> __ntable = new Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>>();
 #else

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -45,7 +45,7 @@ namespace MLAPI
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-#if UNITY_2020_2_OR_NEWER && !UNITY_2021_1_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `public`
         internal static readonly Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>> __ntable = new Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>>();
 #else

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using UnityEngine;
 using System.Linq;
 using MLAPI.Logging;
@@ -41,10 +42,14 @@ namespace MLAPI
     [AddComponentMenu("MLAPI/NetworkingManager", -100)]
     public class NetworkingManager : UpdateLoopBehaviour
     {
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `public`
         internal static readonly Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>> __ntable = new Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>>();
 #else
+        [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
         public static readonly Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>> __ntable = new Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>>();
 #endif
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -36,8 +36,7 @@ namespace MLAPI
     [AddComponentMenu("MLAPI/NetworkingManager", -100)]
     public class NetworkingManager : UpdateLoopBehaviour
     {
-        // RuntimeAccessModifiersILPP will make this `public`
-        internal static readonly Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>> __ntable = new Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>>();
+        public static readonly Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>> __ntable = new Dictionary<uint, Action<NetworkedBehaviour, BitReader, ulong>>();
 
         // @mfatihmar (Unity) Begin: Temporary, inbound RPC queue will replace this workaround
         internal readonly Queue<(ArraySegment<byte> payload, float receiveTime)> __loopbackRpcQueue = new Queue<(ArraySegment<byte> payload, float receiveTime)>();

--- a/com.unity.multiplayer.mlapi/package.json
+++ b/com.unity.multiplayer.mlapi/package.json
@@ -12,6 +12,6 @@
   "hideInEditor": false,
   "dependencies": {
     "com.unity.nuget.mono-cecil": "1.10.1-preview.1",
-    "com.unity.collections": "0.14.0-preview.16"
+    "com.unity.collections": "0.9.0-preview.6"
   }
 }


### PR DESCRIPTION
IL Postprocessing has some issues in older versions of Unity where we had been running it in process VS 2020.2+ where we run it out of process which prevents some level of assembly conflicts but also has some different issues. 

This PR does a couple of things, we hook into the `CompilationPipeline `and listens for assemblies who have finished compiling and then does some checking and from there runs the `ILPostprocessor `on the assembly as it had before what makes this work is that the assembly has already been compiled thus we don't run into some of the issues we had in the past. 

This API also keeps backwards compatibility with the Unity `ILPostprocessor `API and can be disabled by setting the `USE_UNITY_ILPP `scripting define and it will flip back over to using the internal Unity one thus making it easy to keep this for older versions of Unity but go back to the Unity version once issues are resolved. 

We also disable RuntimeAccessModifiersILPP which can be re-enabled with `MLAPI_RUNTIME_ILPP` scripting define. At the moment its no longer needed. 

The goal is that we can re-enable the unity version once self-references are fixed and other issues are resolved. 

Tested on 2019.4.18f1 and 2020.2.1f1

Should address (MTT-317/316)