### PR TITLE
feat: RPC Delivery Types

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -17,7 +17,6 @@ using ParameterAttributes = Mono.Cecil.ParameterAttributes;
 using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostProcessor;
 #else
 using ILPPInterface = MLAPI.Editor.CodeGen.ILPostProcessor;
-
 #endif
 
 namespace MLAPI.Editor.CodeGen
@@ -556,16 +555,6 @@ namespace MLAPI.Editor.CodeGen
                     }
 
                     // rpcDelivery
-                    // todo: instructions.Add(processor.Create(rpcDelivery ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
-                    switch (rpcDelivery)
-                    {
-                        default:
-                        case RpcDelivery.Reliable:
-                            break;
-                        case RpcDelivery.Unreliable:
-                            break;
-                    }
-
                     instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)rpcDelivery));
 
                     // BeginSendServerRpc
@@ -590,16 +579,6 @@ namespace MLAPI.Editor.CodeGen
                     }
 
                     // rpcDelivery
-                    // todo: instructions.Add(processor.Create(rpcDelivery ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
-                    switch (rpcDelivery)
-                    {
-                        default:
-                        case RpcDelivery.Reliable:
-                            break;
-                        case RpcDelivery.Unreliable:
-                            break;
-                    }
-
                     instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)rpcDelivery));
 
                     // BeginSendClientRpc
@@ -1417,16 +1396,6 @@ namespace MLAPI.Editor.CodeGen
                     }
 
                     // rpcDelivery
-                    // todo: instructions.Add(processor.Create(rpcDelivery ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
-                    switch (rpcDelivery)
-                    {
-                        default:
-                        case RpcDelivery.Reliable:
-                            break;
-                        case RpcDelivery.Unreliable:
-                            break;
-                    }
-
                     instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)rpcDelivery));
 
                     // EndSendServerRpc
@@ -1453,16 +1422,6 @@ namespace MLAPI.Editor.CodeGen
                     }
 
                     // rpcDelivery
-                    // todo: instructions.Add(processor.Create(rpcDelivery ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
-                    switch (rpcDelivery)
-                    {
-                        default:
-                        case RpcDelivery.Reliable:
-                            break;
-                        case RpcDelivery.Unreliable:
-                            break;
-                    }
-
                     instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)rpcDelivery));
 
                     // EndSendClientRpc

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkedBehaviour.cs
@@ -60,17 +60,17 @@ namespace MLAPI
         [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal BitSerializer __beginSendServerRpc(ServerRpcParams serverRpcParams, bool isReliable)
+        internal BitSerializer __beginSendServerRpc(ServerRpcParams serverRpcParams, RpcDelivery rpcDelivery)
 #else
         [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
-        public BitSerializer __beginSendServerRpc(ServerRpcParams serverRpcParams, bool isReliable)
+        public BitSerializer __beginSendServerRpc(ServerRpcParams serverRpcParams, RpcDelivery rpcDelivery)
 #endif
         {
             var rpcQueueContainer = NetworkingManager.Singleton.rpcQueueContainer;
             var writer = rpcQueueContainer.BeginAddQueueItemToOutboundFrame(
                 RpcQueueContainer.QueueItemType.ServerRpc,
                 Time.realtimeSinceStartup,
-                Transport.MLAPI_STDRPC_CHANNEL,
+                rpcDelivery == RpcDelivery.Reliable ? Transport.MLAPI_RELIABLE_RPC_CHANNEL : Transport.MLAPI_UNRELIABLE_RPC_CHANNEL,
                 /* sendFlags = */ 0,
                 NetworkingManager.Singleton.ServerClientId,
                 /* targetNetworkIds = */ null);
@@ -101,10 +101,10 @@ namespace MLAPI
         [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal void __endSendServerRpc(BitSerializer serializer, ServerRpcParams serverRpcParams, bool isReliable)
+        internal void __endSendServerRpc(BitSerializer serializer, ServerRpcParams serverRpcParams, RpcDelivery rpcDelivery)
 #else
         [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
-        public void __endSendServerRpc(BitSerializer serializer, ServerRpcParams serverRpcParams, bool isReliable)
+        public void __endSendServerRpc(BitSerializer serializer, ServerRpcParams serverRpcParams, RpcDelivery rpcDelivery)
 #endif
         {
             if (serializer == null) return;
@@ -117,10 +117,10 @@ namespace MLAPI
         [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal BitSerializer __beginSendClientRpc(ClientRpcParams clientRpcParams, bool isReliable)
+        internal BitSerializer __beginSendClientRpc(ClientRpcParams clientRpcParams, RpcDelivery rpcDelivery)
 #else
         [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
-        public BitSerializer __beginSendClientRpc(ClientRpcParams clientRpcParams, bool isReliable)
+        public BitSerializer __beginSendClientRpc(ClientRpcParams clientRpcParams, RpcDelivery rpcDelivery)
 #endif
         {
             // This will start a new queue item entry and will then return the writer to the current frame's stream
@@ -128,7 +128,7 @@ namespace MLAPI
             var writer = rpcQueueContainer.BeginAddQueueItemToOutboundFrame(
                 RpcQueueContainer.QueueItemType.ClientRpc,
                 Time.realtimeSinceStartup,
-                Transport.MLAPI_STDRPC_CHANNEL,
+                rpcDelivery == RpcDelivery.Reliable ? Transport.MLAPI_RELIABLE_RPC_CHANNEL : Transport.MLAPI_UNRELIABLE_RPC_CHANNEL,
                 /* sendFlags = */ 0,
                 NetworkId,
                 clientRpcParams.Send.TargetClientIds ?? NetworkingManager.Singleton.ConnectedClientsList.Select(c => c.ClientId).ToArray());
@@ -159,10 +159,10 @@ namespace MLAPI
         [EditorBrowsable(EditorBrowsableState.Never)]
 #if UNITY_2020_2_OR_NEWER
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal void __endSendClientRpc(BitSerializer serializer, ClientRpcParams clientRpcParams, bool isReliable)
+        internal void __endSendClientRpc(BitSerializer serializer, ClientRpcParams clientRpcParams, RpcDelivery rpcDelivery)
 #else
         [Obsolete("Please do not use, will no longer be exposed in the future versions (framework internal)")]
-        public void __endSendClientRpc(BitSerializer serializer, ClientRpcParams clientRpcParams, bool isReliable)
+        public void __endSendClientRpc(BitSerializer serializer, ClientRpcParams clientRpcParams, RpcDelivery rpcDelivery)
 #endif
         {
             if (serializer == null) return;

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/RpcAttributes.cs
@@ -36,6 +36,10 @@ namespace MLAPI.Messaging
     [AttributeUsage(AttributeTargets.Method)]
     public class ServerRpcAttribute : RpcAttribute
     {
+        /// <summary>
+        /// Whether or not the ServerRpc should only be run if executed by the owner of the object
+        /// </summary>
+        public bool RequireOwnership = true;
     }
 
     /// <summary>

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/RpcAttributes.cs
@@ -3,11 +3,30 @@ using System;
 namespace MLAPI.Messaging
 {
     /// <summary>
+    /// RPC delivery types
+    /// </summary>
+    public enum RpcDelivery
+    {
+        /// <summary>
+        /// Reliable delivery
+        /// </summary>
+        Reliable = 0,
+
+        /// <summary>
+        /// Unreliable delivery
+        /// </summary>
+        Unreliable
+    }
+
+    /// <summary>
     /// <para>Represents the common base class for Rpc attributes.</para>
     /// </summary>
     public abstract class RpcAttribute : Attribute
     {
-        public bool IsReliable = true;
+        /// <summary>
+        /// Type of RPC delivery method
+        /// </summary>
+        public RpcDelivery Delivery = RpcDelivery.Reliable;
     }
 
     /// <summary>
@@ -17,10 +36,6 @@ namespace MLAPI.Messaging
     [AttributeUsage(AttributeTargets.Method)]
     public class ServerRpcAttribute : RpcAttribute
     {
-        /// <summary>
-        /// Whether or not the ServerRpc should only be run if executed by the owner of the object
-        /// </summary>
-        public bool RequireOwnership = true;
     }
 
     /// <summary>

--- a/com.unity.multiplayer.mlapi/Runtime/Transports/Transport.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/Transport.cs
@@ -71,8 +71,9 @@ namespace MLAPI.Transports
         }
 
         public const byte MLAPI_INTERNAL_CHANNEL = 0;
-        public const byte MLAPI_STDRPC_CHANNEL = 1;
         public const byte MLAPI_TIME_SYNC_CHANNEL = 2;
+        public const byte MLAPI_RELIABLE_RPC_CHANNEL = 100;
+        public const byte MLAPI_UNRELIABLE_RPC_CHANNEL = 101;
 
         public static string GetChannelString(byte channel)
         {
@@ -96,16 +97,17 @@ namespace MLAPI.Transports
         /// <summary>
         /// The channels the MLAPI will use when sending internal messages.
         /// </summary>
-        private TransportChannel[] MLAPI_INTERNAL_CHANNELS = new TransportChannel[]
+        private readonly TransportChannel[] MLAPI_INTERNAL_CHANNELS =
         {
             new TransportChannel("MLAPI_INTERNAL", ChannelType.ReliableFragmentedSequenced, MLAPI_INTERNAL_CHANNEL),
-            new TransportChannel("STDRPC", ChannelType.ReliableSequenced, MLAPI_STDRPC_CHANNEL),
             new TransportChannel("MLAPI_TIME_SYNC", ChannelType.Unreliable, MLAPI_TIME_SYNC_CHANNEL),
             new TransportChannel("MLAPI_DEFAULT_MESSAGE", ChannelType.Reliable, 3),
             new TransportChannel("MLAPI_POSITION_UPDATE", ChannelType.UnreliableSequenced, 4),
-            new TransportChannel("MLAPI_ANIMATION_UPDATE", ChannelType.ReliableSequenced,5 ),
+            new TransportChannel("MLAPI_ANIMATION_UPDATE", ChannelType.ReliableSequenced, 5),
             new TransportChannel("MLAPI_NAV_AGENT_STATE", ChannelType.ReliableSequenced, 6),
             new TransportChannel("MLAPI_NAV_AGENT_CORRECTION", ChannelType.UnreliableSequenced, 7),
+            new TransportChannel(nameof(MLAPI_RELIABLE_RPC_CHANNEL), ChannelType.ReliableSequenced, MLAPI_RELIABLE_RPC_CHANNEL),
+            new TransportChannel(nameof(MLAPI_UNRELIABLE_RPC_CHANNEL), ChannelType.Unreliable, MLAPI_UNRELIABLE_RPC_CHANNEL),
         };
 
         /// <summary>


### PR DESCRIPTION
- Replaces `RpcAttribute`'s `bool IsReliable` flag with `RpcDelivery` type, adds related transport-level channels.
- ~~Removes `bool RequireOwnership` flag until we (re)design ownership/control management systems.~~
  - ~~_**note:** after this change, every client can execute RPCs on the server-side without having ownership._~~
  - based on our discussion, we want to keep `bool RequireOwnership` flag until we have an immediate replacement. I will update this PR accordingly. (done ✔️)