### PR TITLE
feat: implement NetworkTickSystem based on NetworkUpdateLoop

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+namespace MLAPI
+{
+    public class NetworkTickSystem : INetworkUpdateSystem
+    {
+        private const double k_DefaultTickDuration = 0.016;
+        private double m_TickDuration;
+        private int m_NetworkTick; //How many network ticks have passed?
+
+        private static NetworkTickSystem m_Instance = null;
+
+        // special value to indicate "No tick information"
+        public const ushort k_NoTick = ushort.MaxValue;
+        // Number of ticks over which the tick number wraps back to 0
+        public const ushort k_TickPeriod = k_NoTick - 1;
+
+        public static NetworkTickSystem Instance
+        {
+            get
+            {
+                if (m_Instance == null)
+                {
+                    m_Instance = new NetworkTickSystem();
+                }
+                return m_Instance;
+            }
+        }
+
+        /// <summary>
+        /// GetTick
+        /// Gets the current network tick (non-fractional, wrapping around)
+        /// </summary>
+        /// <returns></returns>
+        public ushort GetTick()
+        {
+            return (ushort)(m_NetworkTick % k_TickPeriod);
+        }
+
+        /// <summary>
+        /// GetNetworkTime
+        /// Network time is calculated from m_NetworkTick and m_TickDuration (tick frequency)
+        /// </summary>
+        /// <returns>Network Time</returns>
+        public double GetNetworkTime()
+        {
+            return m_NetworkTick * m_TickDuration;
+        }
+
+        /// <summary>
+        /// UpdateNetworkTick
+        /// Called each network loop update during the PreUpdate stage
+        /// </summary>
+        private void UpdateNetworkTick()
+        {
+            m_NetworkTick = (int)(Time.unscaledTime / m_TickDuration);
+        }
+
+        /// <summary>
+        /// Constructor
+        /// Defaults to k_DefaultTickDuration if no tick duration is specified
+        /// </summary>
+        /// <param name="tickDuration">Duration of a network tick</param>
+        public NetworkTickSystem(double tickDuration = k_DefaultTickDuration)
+        {
+            //Assure we don't specify a value less than or equal to zero for tick frequency
+            m_TickDuration = (tickDuration <= 0d) ? k_DefaultTickDuration : tickDuration;
+
+            // ticks might not start at 0, so let's update right away at construction
+            UpdateNetworkTick();
+        }
+
+        public void NetworkUpdate(NetworkUpdateStage updateStage)
+        {
+            switch (updateStage)
+            {
+                case NetworkUpdateStage.EarlyUpdate:
+                    UpdateNetworkTick();
+                    break;
+            }
+        }
+    }
+}

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
@@ -1,8 +1,9 @@
+using System;
 using UnityEngine;
 
 namespace MLAPI
 {
-    public class NetworkTickSystem : INetworkUpdateSystem
+    public class NetworkTickSystem : INetworkUpdateSystem, IDisposable
     {
         private const double k_DefaultTickDuration = 0.016;
         private double m_TickDuration;
@@ -25,6 +26,11 @@ namespace MLAPI
                 }
                 return m_Instance;
             }
+        }
+
+        public void Dispose()
+        {
+            NetworkUpdateLoop.UnregisterNetworkUpdate(this, NetworkUpdateStage.EarlyUpdate);
         }
 
         /// <summary>
@@ -61,8 +67,10 @@ namespace MLAPI
         /// Defaults to k_DefaultTickDuration if no tick duration is specified
         /// </summary>
         /// <param name="tickDuration">Duration of a network tick</param>
-        public NetworkTickSystem(double tickDuration = k_DefaultTickDuration)
+        private NetworkTickSystem(double tickDuration = k_DefaultTickDuration)
         {
+            NetworkUpdateLoop.RegisterNetworkUpdate(this, NetworkUpdateStage.EarlyUpdate);
+
             //Assure we don't specify a value less than or equal to zero for tick frequency
             m_TickDuration = (tickDuration <= 0d) ? k_DefaultTickDuration : tickDuration;
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
@@ -5,9 +5,9 @@ namespace MLAPI
 {
     public class NetworkTickSystem : INetworkUpdateSystem, IDisposable
     {
-        private const float k_DefaultTickDuration = 1/60f; // Default to 60 FPS
-        private float m_TickInterval; //Duration of a tick
-        private int m_NetworkTickCount; //How many network ticks have passed?
+        private const float k_DefaultTickInterval = 1/60f; // Defaults to 60 ticks second
+        private float m_TickInterval; // Duration of a tick in seconds
+        private int m_NetworkTickCount; // How many network ticks have passed?
 
         private static NetworkTickSystem m_Instance = null;
 
@@ -30,15 +30,15 @@ namespace MLAPI
 
         /// <summary>
         /// Constructor
-        /// Defaults to k_DefaultTickDuration if no tick duration is specified
+        /// Defaults to k_DefaultTickInterval if no tick duration is specified
         /// </summary>
         /// <param name="tickInterval">Duration of a network tick</param>
-        private NetworkTickSystem(float tickInterval = k_DefaultTickDuration)
+        private NetworkTickSystem(float tickInterval = k_DefaultTickInterval)
         {
             this.RegisterNetworkUpdate(NetworkUpdateStage.EarlyUpdate);
 
             //Assure we don't specify a value less than or equal to zero for tick frequency
-            m_TickInterval = (tickInterval <= 0f) ? k_DefaultTickDuration : tickInterval;
+            m_TickInterval = (tickInterval <= 0f) ? k_DefaultTickInterval : tickInterval;
 
             // ticks might not start at 0, so let's update right away at construction
             UpdateNetworkTick();

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
@@ -3,6 +3,11 @@ using UnityEngine;
 
 namespace MLAPI
 {
+    // todo: This is a pretty minimal tick system. It will be improved in the future
+    // It currently relies on Time.unscaledTime and, as such, will start suffering
+    // numerical precision issues after 2^23 ticks have passed (float have 23 bits mantissa)
+    // For future releases, we'll need to improve on this, probably by leveraging FixedUpdate
+
     public class NetworkTickSystem : INetworkUpdateSystem, IDisposable
     {
         private const float k_DefaultTickIntervalSec = 1/60f; // Defaults to 60 ticks second
@@ -16,24 +21,12 @@ namespace MLAPI
         // Number of ticks over which the tick number wraps back to 0
         public const ushort k_TickPeriod = k_NoTick - 1;
 
-        public static NetworkTickSystem Instance
-        {
-            get
-            {
-                if (m_Instance == null)
-                {
-                    m_Instance = new NetworkTickSystem();
-                }
-                return m_Instance;
-            }
-        }
-
         /// <summary>
         /// Constructor
         /// Defaults to k_DefaultTickIntervalSec if no tick duration is specified
         /// </summary>
         /// <param name="tickIntervalSec">Duration of a network tick</param>
-        private NetworkTickSystem(float tickIntervalSec = k_DefaultTickIntervalSec)
+        public NetworkTickSystem(float tickIntervalSec = k_DefaultTickIntervalSec)
         {
             this.RegisterNetworkUpdate(NetworkUpdateStage.EarlyUpdate);
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs
@@ -5,8 +5,8 @@ namespace MLAPI
 {
     public class NetworkTickSystem : INetworkUpdateSystem, IDisposable
     {
-        private const float k_DefaultTickInterval = 1/60f; // Defaults to 60 ticks second
-        private float m_TickInterval; // Duration of a tick in seconds
+        private const float k_DefaultTickIntervalSec = 1/60f; // Defaults to 60 ticks second
+        private float m_TickIntervalSec; // Duration of a tick in seconds
         private int m_NetworkTickCount; // How many network ticks have passed?
 
         private static NetworkTickSystem m_Instance = null;
@@ -30,15 +30,15 @@ namespace MLAPI
 
         /// <summary>
         /// Constructor
-        /// Defaults to k_DefaultTickInterval if no tick duration is specified
+        /// Defaults to k_DefaultTickIntervalSec if no tick duration is specified
         /// </summary>
-        /// <param name="tickInterval">Duration of a network tick</param>
-        private NetworkTickSystem(float tickInterval = k_DefaultTickInterval)
+        /// <param name="tickIntervalSec">Duration of a network tick</param>
+        private NetworkTickSystem(float tickIntervalSec = k_DefaultTickIntervalSec)
         {
             this.RegisterNetworkUpdate(NetworkUpdateStage.EarlyUpdate);
 
             //Assure we don't specify a value less than or equal to zero for tick frequency
-            m_TickInterval = (tickInterval <= 0f) ? k_DefaultTickInterval : tickInterval;
+            m_TickIntervalSec = (tickIntervalSec <= 0f) ? k_DefaultTickIntervalSec : tickIntervalSec;
 
             // ticks might not start at 0, so let's update right away at construction
             UpdateNetworkTick();
@@ -61,12 +61,12 @@ namespace MLAPI
 
         /// <summary>
         /// GetNetworkTime
-        /// Network time is calculated from m_NetworkTickCount and m_TickInterval (tick frequency)
+        /// Network time is calculated from m_NetworkTickCount and m_TickIntervalSec (tick frequency)
         /// </summary>
         /// <returns>Network Time</returns>
         public float GetNetworkTime()
         {
-            return m_NetworkTickCount * m_TickInterval;
+            return m_NetworkTickCount * m_TickIntervalSec;
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace MLAPI
         /// </summary>
         private void UpdateNetworkTick()
         {
-            m_NetworkTickCount = (int)(Time.unscaledTime / m_TickInterval);
+            m_NetworkTickCount = (int)(Time.unscaledTime / m_TickIntervalSec);
         }
 
         public void NetworkUpdate(NetworkUpdateStage updateStage)

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs.meta
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkTickSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d802d09776f224e44af7dc71f09779d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -71,6 +71,7 @@ namespace MLAPI
         static ProfilerMarker s_InvokeRPC = new ProfilerMarker("InvokeRPC");
 #endif
         internal RpcQueueContainer rpcQueueContainer { get; private set; }
+        internal NetworkTickSystem networkTickSystem { get; private set; }
 
         /// <summary>
         /// A synchronized time, represents the time in seconds since the server application started. Is replicated across all clients
@@ -383,6 +384,12 @@ namespace MLAPI
                 return;
             }
 
+            //This 'if' should never enter
+            if (networkTickSystem != null)
+            {
+                networkTickSystem.Dispose();
+            }
+            networkTickSystem = new NetworkTickSystem();
 
             //This should never happen, but in the event that it does there should be (at a minimum) a unity error logged.
             if(rpcQueueContainer != null)
@@ -697,6 +704,12 @@ namespace MLAPI
                 rpcQueueContainer.Shutdown();
                 rpcQueueContainer = null;
             }
+
+            if (networkTickSystem != null)
+            {
+                networkTickSystem.Dispose();
+            }
+            networkTickSystem = null;
 
             NetworkProfiler.Stop();
             IsListening = false;


### PR DESCRIPTION
Implements the very minimal part of a tick system we need for synced networked variables.

I tried to keep it to the bare minimum and avoid any difficult design decision. This would be a first stepping stone. 

Later on, we can consider what it means to pause/resume the tick system, to scale time, etc. Tests are pending, I'll get started on them.