### PR TITLE
refactor!: Removing the old MLAPI Profiler from UNITY_2020_2_OR_LATER

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/MLAPIProfiler.cs
+++ b/com.unity.multiplayer.mlapi/Editor/MLAPIProfiler.cs
@@ -9,11 +9,13 @@ namespace UnityEditor
 {
     public class MLAPIProfiler : EditorWindow
     {
+#if !UNITY_2020_2_OR_LATER
         [MenuItem("Window/MLAPI Profiler")]
         public static void ShowWindow()
         {
             GetWindow<MLAPIProfiler>();
         }
+#endif
 
         GUIStyle wrapStyle
         {

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -677,7 +677,9 @@ namespace MLAPI
             }
             networkTickSystem = null;
 
+#if !UNITY_2020_2_OR_LATER
             NetworkProfiler.Stop();
+#endif
             IsListening = false;
             IsServer = false;
             IsClient = false;
@@ -731,7 +733,9 @@ namespace MLAPI
 #endif
                     var IsLoopBack = false;
 
+#if !UNITY_2020_2_OR_LATER
                     NetworkProfiler.StartTick(TickType.Receive);
+#endif
 
                     //If we are in loopback mode, we don't need to touch the transport
                     if (!IsLoopBack)
@@ -750,7 +754,9 @@ namespace MLAPI
 
                     m_LastReceiveTickTime = NetworkTime;
 
+#if !UNITY_2020_2_OR_LATER
                     NetworkProfiler.EndTick();
+#endif
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_ReceiveTick.End();
@@ -769,7 +775,7 @@ namespace MLAPI
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_EventTick.Begin();
 #endif
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_2_OR_LATER
                     NetworkProfiler.StartTick(TickType.Event);
 #endif
 
@@ -794,7 +800,7 @@ namespace MLAPI
                     {
                         m_LastEventTickTime = NetworkTime;
                     }
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_2_OR_LATER
                     NetworkProfiler.EndTick();
 #endif
 
@@ -804,25 +810,25 @@ namespace MLAPI
                 }
                 else if (IsServer && m_EventOvershootCounter >= ((1f / NetworkConfig.EventTickrate)))
                 {
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_2_OR_LATER
                     NetworkProfiler.StartTick(TickType.Event);
 #endif
                     //We run this one to compensate for previous update overshoots.
                     m_EventOvershootCounter -= (1f / NetworkConfig.EventTickrate);
                     LagCompensationManager.AddFrames();
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_2_OR_LATER
                     NetworkProfiler.EndTick();
 #endif
                 }
 
                 if (IsServer && NetworkConfig.EnableTimeResync && NetworkTime - m_LastTimeSyncTime >= NetworkConfig.TimeResyncInterval)
                 {
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_2_OR_LATER
                     NetworkProfiler.StartTick(TickType.Event);
 #endif
                     SyncTime();
                     m_LastTimeSyncTime = NetworkTime;
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_2_OR_LATER
                     NetworkProfiler.EndTick();
 #endif
                 }
@@ -903,7 +909,9 @@ namespace MLAPI
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_TransportConnect.Begin();
 #endif
+#if !UNITY_2020_2_OR_LATER
                     NetworkProfiler.StartEvent(TickType.Receive, (uint)payload.Count, channel, "TRANSPORT_CONNECT");
+#endif
                     if (IsServer)
                     {
                         if (NetworkLog.CurrentLogLevel <= LogLevel.Developer) NetworkLog.LogInfo("Client Connected");
@@ -922,7 +930,9 @@ namespace MLAPI
                         SendConnectionRequest();
                         StartCoroutine(ApprovalTimeout(clientId));
                     }
+#if !UNITY_2020_2_OR_LATER
                     NetworkProfiler.EndEvent();
+#endif
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_TransportConnect.End();
 #endif
@@ -937,7 +947,9 @@ namespace MLAPI
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_TransportDisconnect.Begin();
 #endif
+#if !UNITY_2020_2_OR_LATER
                     NetworkProfiler.StartEvent(TickType.Receive, 0, Channel.Internal, "TRANSPORT_DISCONNECT");
+#endif
 
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Developer) NetworkLog.LogInfo("Disconnect Event From " + clientId);
 
@@ -951,7 +963,10 @@ namespace MLAPI
 
                     if (OnClientDisconnectCallback != null)
                         OnClientDisconnectCallback.Invoke(clientId);
+
+#if !UNITY_2020_2_OR_LATER
                     NetworkProfiler.EndEvent();
+#endif
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_TransportDisconnect.End();
 #endif
@@ -988,7 +1003,10 @@ namespace MLAPI
                 }
 
                 uint headerByteSize = (uint)Arithmetic.VarIntSize(messageType);
+
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.StartEvent(TickType.Receive, (uint)(data.Count - headerByteSize), channel, messageType);
+#endif
 
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Developer) NetworkLog.LogInfo("Data Header: messageType=" + messageType);
 
@@ -1117,7 +1135,9 @@ namespace MLAPI
                 }
                 #endregion
 
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.EndEvent();
+#endif
             }
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             s_HandleIncomingData.End();

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageSender.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageSender.cs
@@ -18,13 +18,17 @@ namespace MLAPI.Messaging
 
             using (BitStream stream = MessagePacker.WrapMessage(messageType, messageStream))
             {
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.StartEvent(TickType.Send, (uint)stream.Length, channel, MLAPIConstants.MESSAGE_NAMES[messageType]);
+#endif
 
                 NetworkingManager.Singleton.NetworkConfig.NetworkTransport.Send(clientId, new ArraySegment<byte>(stream.GetBuffer(), 0, (int)stream.Length), channel);
                 ProfilerStatManager.bytesSent.Record((int)stream.Length);
                 PerformanceDataManager.Increment(ProfilerConstants.NumberBytesSent, (int)stream.Length);
 
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.EndEvent();
+#endif
             }
         }
 
@@ -34,7 +38,9 @@ namespace MLAPI.Messaging
 
             using (BitStream stream = MessagePacker.WrapMessage(messageType, messageStream))
             {
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.StartEvent(TickType.Send, (uint)stream.Length, channel, MLAPIConstants.MESSAGE_NAMES[messageType]);
+#endif
                 for (int i = 0; i < NetworkingManager.Singleton.ConnectedClientsList.Count; i++)
                 {
                     if (NetworkingManager.Singleton.IsServer && NetworkingManager.Singleton.ConnectedClientsList[i].ClientId == NetworkingManager.Singleton.ServerClientId)
@@ -44,8 +50,9 @@ namespace MLAPI.Messaging
                     ProfilerStatManager.bytesSent.Record((int)stream.Length);
                     PerformanceDataManager.Increment(ProfilerConstants.NumberBytesSent, (int)stream.Length);
                 }
-
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.EndEvent();
+#endif
             }
         }
 
@@ -61,7 +68,9 @@ namespace MLAPI.Messaging
 
             using (BitStream stream = MessagePacker.WrapMessage(messageType, messageStream))
             {
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.StartEvent(TickType.Send, (uint)stream.Length, channel, MLAPIConstants.MESSAGE_NAMES[messageType]);
+#endif
                 for (int i = 0; i < clientIds.Count; i++)
                 {
                     if (NetworkingManager.Singleton.IsServer && clientIds[i] == NetworkingManager.Singleton.ServerClientId)
@@ -71,8 +80,9 @@ namespace MLAPI.Messaging
                     ProfilerStatManager.bytesSent.Record((int)stream.Length);
                     PerformanceDataManager.Increment(ProfilerConstants.NumberBytesSent, (int)stream.Length);
                 }
-
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.EndEvent();
+#endif
             }
         }
 
@@ -82,7 +92,9 @@ namespace MLAPI.Messaging
 
             using (BitStream stream = MessagePacker.WrapMessage(messageType, messageStream))
             {
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.StartEvent(TickType.Send, (uint)stream.Length, channel, MLAPIConstants.MESSAGE_NAMES[messageType]);
+#endif
                 for (int i = 0; i < NetworkingManager.Singleton.ConnectedClientsList.Count; i++)
                 {
                     if (NetworkingManager.Singleton.ConnectedClientsList[i].ClientId == clientIdToIgnore ||
@@ -93,8 +105,9 @@ namespace MLAPI.Messaging
                     ProfilerStatManager.bytesSent.Record((int)stream.Length);
                     PerformanceDataManager.Increment(ProfilerConstants.NumberBytesSent, (int)stream.Length);
                 }
-
+#if !UNITY_2020_2_OR_LATER
                 NetworkProfiler.EndEvent();
+#endif
             }
         }
     }


### PR DESCRIPTION
Removing the old MLAPI Profiler from UNITY_2020_2_OR_LATER in favor of using the new profiler data propagation