### PR TITLE
fix: do NOT call Shutdown() before Singleton = null on NetworkManager.OnDestroy()

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkingManager.cs
@@ -652,8 +652,8 @@ namespace MLAPI
         {
             if (Singleton != null && Singleton == this)
             {
-                Singleton = null;
                 Shutdown();
+                Singleton = null;
             }
         }
 


### PR DESCRIPTION
I noticed this issue when I encountered this `NullReferenceException` callstack:

- `MLAPI.NetworkingManager.OnDestroy()`
  - `MLAPI.NetworkingManager.Shutdown()`
    - `MLAPI.Messaging.RpcQueueContainer.Shutdown()`
      - `MLAPI.Messaging.RpcQueueProcessor.InternalMessagesSendAndFlush()`
        - **NullReferenceException: Object reference not set to an instance of an object**

We are making `NetworkManager.Singleton = null` then call `NetworkManager.Shutdown()` which causes this issue.

I think even regardless of this issue, we should NOT make `NetworkManager.Singleton = null` since other systems might still access the `NetworkManager` while shutting themselves down, similar to the issue we're seeing here.