### PR TITLE
test: expose runtime internals to runtime tests asmdef

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/AssemblyInfo.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/AssemblyInfo.cs
@@ -6,4 +6,5 @@
 
 #if UNITY_EDITOR
 [assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.EditorTests")]
+[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.RuntimeTests")]
 #endif


### PR DESCRIPTION
currently, RuntimeTests asmdef can't access MLAPI Runtime internals which is a blocker for writing PlayMode tests

with this PR, RuntimeTests asmdef will be able to access MLAPI Runtime internals such as `InternalMessageSender`, `RpcQueueContainer` etc.