### PR TITLE
ci: enable yamato on PRs targeting master, develop and release/* branches

### DIFF
--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -132,4 +132,6 @@ develop_pull_request_trigger:
     pull_requests:
     - targets:
         only:
-          - "release/0.1.0"
+          - "master"
+          - "develop"
+          - "/release\/.+/"

--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -132,4 +132,4 @@ develop_pull_request_trigger:
     pull_requests:
     - targets:
         only:
-          - "develop"
+          - "release/0.1.0"

--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -134,4 +134,4 @@ develop_pull_request_trigger:
         only:
           - "master"
           - "develop"
-          - "/release\/.+/"
+          - "/release/.*/"


### PR DESCRIPTION
we should run tests on release branches over Yamato CI pipeline