### PR TITLE
ci: enable conventional PR checks on PRs targeting release branches

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -6,7 +6,6 @@ on:
     branches:
     - master
     - develop
-    - release/*
     - release/**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -6,6 +6,8 @@ on:
     branches:
     - master
     - develop
+    - release/*
+    - release/**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
with this, conventional PR commit messages are also going to be checked on PRs targeting "release/*" branches