### PR TITLE
refactor: Improve error messages for NetworkPrefab list.

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -204,7 +204,7 @@ namespace MLAPI
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                 {
-                    NetworkLog.LogWarning($"{nameof(NetworkManager)} cannot be a {nameof(NetworkObject)}. This will lead to weird side effects.");
+                    NetworkLog.LogWarning($"{nameof(NetworkManager)} cannot be a {nameof(NetworkObject)}.");
                 }
             }
 
@@ -360,14 +360,14 @@ namespace MLAPI
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
-                        NetworkLog.LogError($"{nameof(NetworkPrefab)} cannot be null");
+                        NetworkLog.LogError($"{nameof(NetworkPrefab)} cannot be null ({nameof(NetworkPrefab)} at index: {i})");
                     }
                 }
                 else if (ReferenceEquals(NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>(), null))
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
-                        NetworkLog.LogError($"{nameof(NetworkPrefab)} is missing a {nameof(NetworkObject)} component");
+                        NetworkLog.LogError($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") is missing a {nameof(NetworkObject)} component");
                     }
                 }
                 else
@@ -932,7 +932,7 @@ namespace MLAPI
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
-                        NetworkLog.LogError("Message unwrap could not be completed. Was the header corrupt? Crypto error?");
+                        NetworkLog.LogError("Message unwrap could not be completed. Was the header corrupt?");
                     }
 
                     return;


### PR DESCRIPTION
Refactor error messaging around adding/removing network prefabs from the config to be more descriptive on what you are doing wrong.