### PR TITLE
fix: call WriteBool instead of WriteBit on NetworkWriter.WriteObjectPacked when serializing bool object

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
@@ -142,7 +142,7 @@ namespace MLAPI.Serialization
             }
             else if (value is bool)
             {
-                WriteBit((bool)value);
+                WriteBool((bool)value);
                 return;
             }
             else if (value is Vector2)


### PR DESCRIPTION
`NetworkReader.ReadObjectPacked()` uses `ReadBool()` and this `NetworkWriter.WriteObjectPacked()` method should also use `WriteBool()` method instead of calling `WriteBit()` directly.

This was causing a serialization error because the underlying type of bool is no longer bit, it's byte now (will fix bits later).