### PR TITLE
fix: re-fix yamato release branch wildcard regex

### DIFF
--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -134,4 +134,4 @@ develop_pull_request_trigger:
         only:
           - "master"
           - "develop"
-          - "/release/.*/"
+          - "/release\/.*/"


### PR DESCRIPTION
was missing the backslash escape character before the forwardslash :)