### PR TITLE
fix: (unfix) revert Application.isPlaying check in NetworkScenePostProcess

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/PostProcessScene.cs
+++ b/com.unity.multiplayer.mlapi/Editor/PostProcessScene.cs
@@ -11,12 +11,6 @@ namespace UnityEditor
         [PostProcessScene(int.MaxValue)]
         public static void ProcessScene()
         {
-            //If we are in playmode (editor or stand alone) we do not want this to execute
-            if (Application.isPlaying)
-            {
-                return;
-            }
-
             var traverseSortedObjects = FindObjectsOfType<NetworkObject>().ToList();
 
             traverseSortedObjects.Sort((x, y) =>


### PR DESCRIPTION
this PR reverts (unfixes) [#493 fix: No longer re-assign network instance ids on scene load](https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/pull/493)

it is not a proper fix and probably doesn't fix what is intended to be fixed.

we'll have another attempt to fix in the future.