### PR TITLE
test: implement test for NetworkUpdateLoop injecting NetworkUpdateStages into the PlayerLoop

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -150,7 +150,7 @@ namespace MLAPI
             }
         }
 
-        private struct NetworkInitialization
+        internal struct NetworkInitialization
         {
             public static PlayerLoopSystem CreateLoopSystem()
             {

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -162,7 +162,7 @@ namespace MLAPI
             }
         }
 
-        private struct NetworkEarlyUpdate
+        internal struct NetworkEarlyUpdate
         {
             public static PlayerLoopSystem CreateLoopSystem()
             {
@@ -174,7 +174,7 @@ namespace MLAPI
             }
         }
 
-        private struct NetworkFixedUpdate
+        internal struct NetworkFixedUpdate
         {
             public static PlayerLoopSystem CreateLoopSystem()
             {
@@ -186,7 +186,7 @@ namespace MLAPI
             }
         }
 
-        private struct NetworkPreUpdate
+        internal struct NetworkPreUpdate
         {
             public static PlayerLoopSystem CreateLoopSystem()
             {
@@ -198,7 +198,7 @@ namespace MLAPI
             }
         }
 
-        private struct NetworkUpdate
+        internal struct NetworkUpdate
         {
             public static PlayerLoopSystem CreateLoopSystem()
             {
@@ -210,7 +210,7 @@ namespace MLAPI
             }
         }
 
-        private struct NetworkPreLateUpdate
+        internal struct NetworkPreLateUpdate
         {
             public static PlayerLoopSystem CreateLoopSystem()
             {
@@ -222,7 +222,7 @@ namespace MLAPI
             }
         }
 
-        private struct NetworkPostLateUpdate
+        internal struct NetworkPostLateUpdate
         {
             public static PlayerLoopSystem CreateLoopSystem()
             {

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
@@ -12,7 +12,7 @@ namespace MLAPI.RuntimeTests
     public class NetworkUpdateLoopTests
     {
         [Test]
-        public void VerifyInjectedStages()
+        public void UpdateStageInjection()
         {
             var currentPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
             for (int i = 0; i < currentPlayerLoop.subSystemList.Length; i++)
@@ -26,12 +26,42 @@ namespace MLAPI.RuntimeTests
                         subsystems.Exists(s => s.type == typeof(NetworkUpdateLoop.NetworkInitialization)),
                         nameof(NetworkUpdateLoop.NetworkInitialization));
                 }
-                else if (playerLoopSystem.type == typeof(EarlyUpdate)) { }
-                else if (playerLoopSystem.type == typeof(FixedUpdate)) { }
-                else if (playerLoopSystem.type == typeof(PreUpdate)) { }
-                else if (playerLoopSystem.type == typeof(Update)) { }
-                else if (playerLoopSystem.type == typeof(PreLateUpdate)) { }
-                else if (playerLoopSystem.type == typeof(PostLateUpdate)) { }
+                else if (playerLoopSystem.type == typeof(EarlyUpdate))
+                {
+                    Assert.True(
+                        subsystems.Exists(s => s.type == typeof(NetworkUpdateLoop.NetworkEarlyUpdate)),
+                        nameof(NetworkUpdateLoop.NetworkEarlyUpdate));
+                }
+                else if (playerLoopSystem.type == typeof(FixedUpdate))
+                {
+                    Assert.True(
+                        subsystems.Exists(s => s.type == typeof(NetworkUpdateLoop.NetworkFixedUpdate)),
+                        nameof(NetworkUpdateLoop.NetworkFixedUpdate));
+                }
+                else if (playerLoopSystem.type == typeof(PreUpdate))
+                {
+                    Assert.True(
+                        subsystems.Exists(s => s.type == typeof(NetworkUpdateLoop.NetworkPreUpdate)),
+                        nameof(NetworkUpdateLoop.NetworkPreUpdate));
+                }
+                else if (playerLoopSystem.type == typeof(Update))
+                {
+                    Assert.True(
+                        subsystems.Exists(s => s.type == typeof(NetworkUpdateLoop.NetworkUpdate)),
+                        nameof(NetworkUpdateLoop.NetworkUpdate));
+                }
+                else if (playerLoopSystem.type == typeof(PreLateUpdate))
+                {
+                    Assert.True(
+                        subsystems.Exists(s => s.type == typeof(NetworkUpdateLoop.NetworkPreLateUpdate)),
+                        nameof(NetworkUpdateLoop.NetworkPreLateUpdate));
+                }
+                else if (playerLoopSystem.type == typeof(PostLateUpdate))
+                {
+                    Assert.True(
+                        subsystems.Exists(s => s.type == typeof(NetworkUpdateLoop.NetworkPostLateUpdate)),
+                        nameof(NetworkUpdateLoop.NetworkPostLateUpdate));
+                }
             }
         }
 

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
@@ -1,13 +1,40 @@
 using System;
 using System.Collections;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
+using UnityEngine.LowLevel;
+using UnityEngine.PlayerLoop;
 
 namespace MLAPI.RuntimeTests
 {
     public class NetworkUpdateLoopTests
     {
+        [Test]
+        public void VerifyInjectedStages()
+        {
+            var currentPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
+            for (int i = 0; i < currentPlayerLoop.subSystemList.Length; i++)
+            {
+                var playerLoopSystem = currentPlayerLoop.subSystemList[i];
+                var subsystems = playerLoopSystem.subSystemList.ToList();
+
+                if (playerLoopSystem.type == typeof(Initialization))
+                {
+                    Assert.True(
+                        subsystems.Exists(s => s.type == typeof(NetworkUpdateLoop.NetworkInitialization)),
+                        nameof(NetworkUpdateLoop.NetworkInitialization));
+                }
+                else if (playerLoopSystem.type == typeof(EarlyUpdate)) { }
+                else if (playerLoopSystem.type == typeof(FixedUpdate)) { }
+                else if (playerLoopSystem.type == typeof(PreUpdate)) { }
+                else if (playerLoopSystem.type == typeof(Update)) { }
+                else if (playerLoopSystem.type == typeof(PreLateUpdate)) { }
+                else if (playerLoopSystem.type == typeof(PostLateUpdate)) { }
+            }
+        }
+
         private struct NetworkUpdateCallbacks
         {
             public Action OnInitialization;


### PR DESCRIPTION
this test will verify that `NetworkUpdateLoop` injects `NetworkUpdateStage`s into Unity's low-level `PlayerLoop` at relevant places.