### PR TITLE
test: implement extra features on top of existing NetworkUpdateLoopTests to cover other test cases

### DIFF
--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
@@ -224,6 +224,14 @@ namespace MLAPI.RuntimeTests
                 this.RegisterNetworkUpdate(NetworkUpdateStage.FixedUpdate);
                 this.RegisterNetworkUpdate(NetworkUpdateStage.PreUpdate);
                 this.RegisterNetworkUpdate(NetworkUpdateStage.PreLateUpdate);
+                this.RegisterNetworkUpdate(NetworkUpdateStage.PostLateUpdate);
+
+                // intentionally try to register for `PreUpdate` stage twice
+                // it should be ignored and the instance should not be registered twice
+                // otherwise test would fail because it would call `OnPreUpdate()` twice
+                // which would ultimately increment `netUpdates[idx]` integer twice
+                // and cause `Assert.AreEqual()` to fail the test
+                this.RegisterNetworkUpdate(NetworkUpdateStage.PreUpdate);
             }
 
             public void NetworkUpdate(NetworkUpdateStage updateStage)
@@ -238,6 +246,9 @@ namespace MLAPI.RuntimeTests
                         break;
                     case NetworkUpdateStage.PreLateUpdate:
                         UpdateCallbacks.OnPreLateUpdate();
+                        break;
+                    case NetworkUpdateStage.PostLateUpdate:
+                        UpdateCallbacks.OnPostLateUpdate();
                         break;
                 }
             }
@@ -269,7 +280,8 @@ namespace MLAPI.RuntimeTests
             const int kNetFixedUpdateIndex = 0;
             const int kNetPreUpdateIndex = 1;
             const int kNetPreLateUpdateIndex = 2;
-            int[] netUpdates = new int[3];
+            const int kNetPostLateUpdateIndex = 3;
+            int[] netUpdates = new int[4];
             const int kMonoFixedUpdateIndex = 0;
             const int kMonoUpdateIndex = 1;
             const int kMonoLateUpdateIndex = 2;
@@ -303,6 +315,14 @@ namespace MLAPI.RuntimeTests
                         {
                             netUpdates[kNetPreLateUpdateIndex]++;
                             Assert.AreEqual(monoUpdates[kMonoLateUpdateIndex] + 1, netUpdates[kNetPreLateUpdateIndex]);
+                        }
+                    },
+                    OnPostLateUpdate = () =>
+                    {
+                        if (isTesting)
+                        {
+                            netUpdates[kNetPostLateUpdateIndex]++;
+                            Assert.AreEqual(netUpdates[kNetPostLateUpdateIndex], netUpdates[kNetPreLateUpdateIndex]);
                         }
                     }
                 };

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
@@ -226,11 +226,11 @@ namespace MLAPI.RuntimeTests
                 this.RegisterNetworkUpdate(NetworkUpdateStage.PreLateUpdate);
                 this.RegisterNetworkUpdate(NetworkUpdateStage.PostLateUpdate);
 
-                // intentionally try to register for `PreUpdate` stage twice
+                // intentionally try to register for 'PreUpdate' stage twice
                 // it should be ignored and the instance should not be registered twice
-                // otherwise test would fail because it would call `OnPreUpdate()` twice
-                // which would ultimately increment `netUpdates[idx]` integer twice
-                // and cause `Assert.AreEqual()` to fail the test
+                // otherwise test would fail because it would call 'OnPreUpdate()' twice
+                // which would ultimately increment 'netUpdates[idx]' integer twice
+                // and cause 'Assert.AreEqual()' to fail the test
                 this.RegisterNetworkUpdate(NetworkUpdateStage.PreUpdate);
             }
 


### PR DESCRIPTION
extending existing `NetworkUpdateLoopTests` implementation further so that it covers:

- Verify NetworkUpdateStage.FixedUpdate runs an equal number of times with MonoBehaviour.FixedUpdate
  - `Assert.AreEqual(netUpdates[kNetFixedUpdateIndex], monoUpdates[kMonoFixedUpdateIndex]);`
- Verify NetworkUpdateStage.Update runs an equal number of times with MonoBehaviour.Update
  - `Assert.AreEqual(netUpdates[kNetPreUpdateIndex], monoUpdates[kMonoUpdateIndex]);`
- Verify NetworkFixedUpdate runs before MonoBehaviour.FixedUpdate
  - `Assert.AreEqual(monoUpdates[kMonoFixedUpdateIndex] + 1, netUpdates[kNetFixedUpdateIndex]);`
- Verify NetworkPreUpdate and NetworkUpdate runs before MonoBehaviour.Update
  - `Assert.AreEqual(monoUpdates[kMonoUpdateIndex] + 1, netUpdates[kNetPreUpdateIndex]);`
- Verify NetworkPreLateUpdate runs before MonoBehaviour.LateUpdate
  - `Assert.AreEqual(monoUpdates[kMonoLateUpdateIndex] + 1, netUpdates[kNetPreLateUpdateIndex]);`
- Verify NetworkPostLateUpdate runs after MonoBehaviour.LateUpdate
  - `Assert.AreEqual(netUpdates[kNetPostLateUpdateIndex], netUpdates[kNetPreLateUpdateIndex]);`
- Verify an INetworkUpdateSystem can NOT be registered and get updated twice per NetworkUpdateStage execution
  - `// intentionally try to register for 'PreUpdate' stage twice`
  - `// it should be ignored and the instance should not be registered twice`
  - `// otherwise test would fail because it would call 'OnPreUpdate()' twice`
  - `// which would ultimately increment 'netUpdates[idx]' integer twice`
  - `// and cause 'Assert.AreEqual()' to fail the test`
  - `this.RegisterNetworkUpdate(NetworkUpdateStage.PreUpdate);`