### PR TITLE
 test: Added regression test for BitWriter / BitReader bool size inconsistency

### DIFF
--- a/com.unity.multiplayer.mlapi/Tests/Editor/BitStreamTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/BitStreamTests.cs
@@ -798,9 +798,9 @@ namespace MLAPI.EditorTests
         [Test]
         public void TestSerializationPipelineBool()
         {
-            NetworkBuffer buffer = new NetworkBuffer();
-            NetworkWriter writer = new NetworkWriter(buffer);
-            NetworkReader reader = new NetworkReader(buffer);
+            var buffer = new NetworkBuffer();
+            var writer = new NetworkWriter(buffer);
+            var reader = new NetworkReader(buffer);
 
             writer.WriteObjectPacked(true);
             writer.WriteObjectPacked(false);

--- a/com.unity.multiplayer.mlapi/Tests/Editor/BitStreamTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/BitStreamTests.cs
@@ -794,5 +794,21 @@ namespace MLAPI.EditorTests
             Assert.That(readBuilder.ToString(), Is.EqualTo(testString));
             Assert.That(stringCompare.ToString(), Is.EqualTo(testString));
         }
+
+        [Test]
+        public void TestSerializationPipelineBool()
+        {
+            NetworkBuffer buffer = new NetworkBuffer();
+            NetworkWriter writer = new NetworkWriter(buffer);
+            NetworkReader reader = new NetworkReader(buffer);
+
+            writer.WriteObjectPacked(true);
+            writer.WriteObjectPacked(false);
+
+            buffer.BitPosition = 0;
+
+            Assert.That(reader.ReadObjectPacked(typeof(bool)), Is.EqualTo(true));
+            Assert.That(reader.ReadObjectPacked(typeof(bool)), Is.EqualTo(false));
+        }
     }
 }

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace MLAPI.EditorTests
 {
-    public class BitStreamTests
+    public class NetworkBufferTests
     {
         [Test]
         public void TestEmptyStream()

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs.meta
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 437e9acc45b6b4752a074d94a25030f6
+guid: ed2672ae96472b0e487aae6e77522ee7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
Expect this to fail until the fix for this has been backported to develop.

Perhaps target release?