### PR TITLE
refactor: better handle instantiating and detecting a lack of NetworkManager availability

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -324,17 +324,13 @@ namespace MLAPI
             if (RpcQueueContainer != null)
             {
                 UnityEngine.Debug.LogError("Init was invoked, but rpcQueueContainer was already initialized! (destroying previous instance)");
-                RpcQueueContainer.Shutdown();
+                RpcQueueContainer.Dispose();
                 RpcQueueContainer = null;
             }
 
             //The RpcQueueContainer must be initialized within the Init method ONLY
             //It should ONLY be shutdown and destroyed in the Shutdown method (other than just above)
-            RpcQueueContainer = new RpcQueueContainer(false);
-
-            //Note: Since frame history is not being used, this is set to 0
-            //To test frame history, increase the number to (n) where n > 0
-            RpcQueueContainer.Initialize(0);
+            RpcQueueContainer = new RpcQueueContainer();
 
             // Register INetworkUpdateSystem (always register this after rpcQueueContainer has been instantiated)
             this.RegisterNetworkUpdate(NetworkUpdateStage.EarlyUpdate);
@@ -599,7 +595,7 @@ namespace MLAPI
             //If an instance of the RpcQueueContainer is still around, then shut it down and remove the reference
             if (RpcQueueContainer != null)
             {
-                RpcQueueContainer.Shutdown();
+                RpcQueueContainer.Dispose();
                 RpcQueueContainer = null;
             }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/RpcQueue/RpcQueueProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/RpcQueue/RpcQueueProcessor.cs
@@ -34,6 +34,11 @@ namespace MLAPI.Messaging
         /// </summary>
         public void ProcessReceiveQueue(NetworkUpdateStage currentStage)
         {
+            if(ReferenceEquals(NetworkManager.Singleton,null))
+            {
+                return;
+            }
+
             bool advanceFrameHistory = false;
             var rpcQueueContainer = NetworkManager.Singleton.RpcQueueContainer;
             if (rpcQueueContainer != null)
@@ -54,12 +59,6 @@ namespace MLAPI.Messaging
                     while (currentQueueItem.QueueItemType != RpcQueueContainer.QueueItemType.None)
                     {
                         advanceFrameHistory = true;
-
-                        if (rpcQueueContainer.IsTesting())
-                        {
-                            Debug.Log($"RPC invoked during the {currentStage} update stage.");
-                        }
-
                         NetworkManager.InvokeRpc(currentQueueItem);
                         ProfilerStatManager.RpcsQueueProc.Record();
                         PerformanceDataManager.Increment(ProfilerConstants.NumberOfRPCQueueProcessed);
@@ -116,6 +115,11 @@ namespace MLAPI.Messaging
         /// </summary>
         public void InternalMessagesSendAndFlush()
         {
+            if(ReferenceEquals(NetworkManager.Singleton,null))
+            {
+                return;
+            }
+
             foreach (RpcFrameQueueItem queueItem in m_InternalMLAPISendQueue)
             {
                 var PoolStream = queueItem.NetworkBuffer;
@@ -160,6 +164,11 @@ namespace MLAPI.Messaging
         /// </summary>
         private void RpcQueueSendAndFlush()
         {
+            if(ReferenceEquals(NetworkManager.Singleton,null))
+            {
+                return;
+            }
+
             var advanceFrameHistory = false;
             var rpcQueueContainer = NetworkManager.Singleton.RpcQueueContainer;
             if (rpcQueueContainer != null)


### PR DESCRIPTION
This refactoring includes additional checks to assure the RpcQueueContainer does not allow itself to be updated via the Network Update Loop system if there is no NetworkManager instantiated or if there is a problem with its initialization.

Refactored the constructor and made the class disposable.
Simplified the constructor process.