### PR TITLE
fix: prevent OnPerformanceTickData from sending data on null

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -643,11 +643,7 @@ namespace MLAPI
 
         private void OnNetworkEarlyUpdate()
         {
-            PerformanceDataManager.BeginNewTick();
-            if (NetworkConfig.NetworkTransport is ITransportProfilerData profileTransport)
-            {
-                profileTransport.BeginNewTick();
-            }
+            ProfilerBeginTick();
 
             if (IsListening)
             {
@@ -751,18 +747,7 @@ namespace MLAPI
                 }
             }
 
-            var data = PerformanceDataManager.GetData();
-            var eventHandler = OnPerformanceDataEvent;
-            if (eventHandler != null && data!= null)
-            {
-                if (NetworkConfig.NetworkTransport is ITransportProfilerData profileTransport)
-                {
-                    var transportProfilerData = profileTransport.GetTransportProfilerData();
-                    PerformanceDataManager.AddTransportData(transportProfilerData);
-                }
-
-                eventHandler?.Invoke(data);
-            }
+            NotifyProfilerListeners();
         }
 
         internal void UpdateNetworkTime(ulong clientId, float netTime, float receiveTime, bool warp = false)
@@ -1489,6 +1474,35 @@ namespace MLAPI
                 }
 
                 NetworkConfig.NetworkTransport.DisconnectRemoteClient(clientId);
+            }
+        }
+
+        private void ProfilerBeginTick()
+        {
+            PerformanceDataManager.BeginNewTick();
+            if (NetworkConfig.NetworkTransport is ITransportProfilerData profileTransport)
+            {
+                profileTransport.BeginNewTick();
+            }
+        }
+
+        private void NotifyProfilerListeners()
+        {
+            var data = PerformanceDataManager.GetData();
+            var eventHandler = OnPerformanceDataEvent;
+            if (eventHandler != null && data != null)
+            {
+                if (NetworkConfig.NetworkTransport is ITransportProfilerData profileTransport)
+                {
+                    var transportProfilerData = profileTransport.GetTransportProfilerData();
+                    PerformanceDataManager.AddTransportData(transportProfilerData);
+                }
+
+                eventHandler.Invoke(data);
+            }
+            else if (data == null)
+            {
+                NetworkLog.LogWarning("No data available. Did you forget to call PerformanceDataManager.BeginNewTick() first?");
             }
         }
     }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -751,13 +751,18 @@ namespace MLAPI
                 }
             }
 
-            if (NetworkConfig.NetworkTransport is ITransportProfilerData profileTransport)
+            var data = PerformanceDataManager.GetData();
+            var eventHandler = OnPerformanceDataEvent;
+            if (eventHandler != null && data!= null)
             {
-                var transportProfilerData = profileTransport.GetTransportProfilerData();
-                PerformanceDataManager.AddTransportData(transportProfilerData);
-            }
+                if (NetworkConfig.NetworkTransport is ITransportProfilerData profileTransport)
+                {
+                    var transportProfilerData = profileTransport.GetTransportProfilerData();
+                    PerformanceDataManager.AddTransportData(transportProfilerData);
+                }
 
-            OnPerformanceDataEvent?.Invoke(PerformanceDataManager.GetData());
+                eventHandler?.Invoke(data);
+            }
         }
 
         internal void UpdateNetworkTime(ulong clientId, float netTime, float receiveTime, bool warp = false)

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -1502,7 +1502,7 @@ namespace MLAPI
             }
             else if (data == null)
             {
-                NetworkLog.LogWarning("No data available. Did you forget to call PerformanceDataManager.BeginNewTick() first?");
+                NetworkLog.LogWarning($"No data available. Did you forget to call {nameof(PerformanceDataManager)}.{nameof(BeginNewTick)}() first?");
             }
         }
     }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -1502,7 +1502,7 @@ namespace MLAPI
             }
             else if (data == null)
             {
-                NetworkLog.LogWarning($"No data available. Did you forget to call {nameof(PerformanceDataManager)}.{nameof(BeginNewTick)}() first?");
+                NetworkLog.LogWarning($"No data available. Did you forget to call {nameof(PerformanceDataManager)}.{nameof(PerformanceDataManager.BeginNewTick)}() first?");
             }
         }
     }

--- a/com.unity.multiplayer.mlapi/Runtime/Profiling/ProfilerCountersInfo.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Profiling/ProfilerCountersInfo.cs
@@ -75,6 +75,9 @@ namespace MLAPI.Profiling
 
         private static void OnPerformanceTickData(PerformanceTickData tickData)
         {
+            if(tickData == null)
+                return;
+
             // Operations
             k_ConnectionsCounterValue.Value = tickData.GetData(ProfilerConstants.NumberOfConnections);
             k_TickRateCounterValue.Value = tickData.GetData(ProfilerConstants.ReceiveTickRate);

--- a/com.unity.multiplayer.mlapi/Runtime/Profiling/ProfilerCountersInfo.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Profiling/ProfilerCountersInfo.cs
@@ -75,9 +75,6 @@ namespace MLAPI.Profiling
 
         private static void OnPerformanceTickData(PerformanceTickData tickData)
         {
-            if(tickData == null)
-                return;
-
             // Operations
             k_ConnectionsCounterValue.Value = tickData.GetData(ProfilerConstants.NumberOfConnections);
             k_TickRateCounterValue.Value = tickData.GetData(ProfilerConstants.ReceiveTickRate);


### PR DESCRIPTION
If something causes an exception it's possible that the profiler never allocates data. in these cases, there is no point in sending data outside of MLAPI