### PR TITLE
fix: revert ReferenceEquals() checks back

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/NetworkAnimatorEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkAnimatorEditor.cs
@@ -35,10 +35,10 @@ namespace UnityEditor
             if (EditorGUI.EndChangeCheck()) m_Target.ResetTrackedParams();
 
             var animator = m_Target.Animator;
-            if (ReferenceEquals(animator, null)) return;
+            if (animator == null) return;
 
             var animatorController = animator.runtimeAnimatorController as AnimatorController;
-            if (ReferenceEquals(animatorController, null)) return;
+            if (animatorController == null) return;
 
             EditorGUI.indentLevel += 1;
             var showWarning = false;

--- a/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
@@ -266,7 +266,7 @@ public class NetworkManagerEditor : Editor
 
                     var transportComponent = m_NetworkManager.gameObject.GetComponent(m_TransportTypes[selection - 1]);
 
-                    if (ReferenceEquals(transportComponent, null))
+                    if (transportComponent == null)
                     {
                         transportComponent = m_NetworkManager.gameObject.AddComponent(m_TransportTypes[selection - 1]);
                     }

--- a/com.unity.multiplayer.mlapi/Editor/NetworkObjectEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkObjectEditor.cs
@@ -24,7 +24,7 @@ namespace UnityEditor
         {
             Init();
 
-            if (!m_NetworkObject.IsSpawned && !ReferenceEquals(NetworkManager.Singleton, null) && NetworkManager.Singleton.IsServer)
+            if (!m_NetworkObject.IsSpawned && NetworkManager.Singleton != null && NetworkManager.Singleton.IsServer)
             {
                 EditorGUILayout.BeginHorizontal();
                 EditorGUILayout.LabelField(new GUIContent("Spawn", "Spawns the object across the network"));

--- a/com.unity.multiplayer.mlapi/Prototyping/NetworkNavMeshAgent.cs
+++ b/com.unity.multiplayer.mlapi/Prototyping/NetworkNavMeshAgent.cs
@@ -65,7 +65,7 @@ namespace MLAPI.Prototyping
                     var proximityClients = new List<ulong>();
                     foreach (KeyValuePair<ulong, NetworkClient> client in NetworkManager.Singleton.ConnectedClients)
                     {
-                        if (ReferenceEquals(client.Value.PlayerObject, null) || Vector3.Distance(client.Value.PlayerObject.transform.position, transform.position) <= ProximityRange)
+                        if (client.Value.PlayerObject == null || Vector3.Distance(client.Value.PlayerObject.transform.position, transform.position) <= ProximityRange)
                         {
                             proximityClients.Add(client.Key);
                         }
@@ -86,7 +86,7 @@ namespace MLAPI.Prototyping
                     var proximityClients = new List<ulong>();
                     foreach (KeyValuePair<ulong, NetworkClient> client in NetworkManager.Singleton.ConnectedClients)
                     {
-                        if (ReferenceEquals(client.Value.PlayerObject, null) || Vector3.Distance(client.Value.PlayerObject.transform.position, transform.position) <= ProximityRange)
+                        if (client.Value.PlayerObject == null || Vector3.Distance(client.Value.PlayerObject.transform.position, transform.position) <= ProximityRange)
                         {
                             proximityClients.Add(client.Key);
                         }

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
@@ -14,7 +14,7 @@ namespace MLAPI.Configuration
         {
             get
             {
-                if (ReferenceEquals(Prefab, null))
+                if (Prefab == null)
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                     {
@@ -25,7 +25,7 @@ namespace MLAPI.Configuration
                 }
 
                 var networkObject = Prefab.GetComponent<NetworkObject>();
-                if (ReferenceEquals(networkObject, null))
+                if (networkObject == null)
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                     {

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -272,12 +272,12 @@ namespace MLAPI
         {
             get
             {
-                if (ReferenceEquals(m_NetworkObject, null))
+                if (m_NetworkObject == null)
                 {
                     m_NetworkObject = GetComponentInParent<NetworkObject>();
                 }
 
-                if (ReferenceEquals(m_NetworkObject, null))
+                if (m_NetworkObject == null)
                 {
                     throw new NullReferenceException($"Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");
                 }
@@ -293,12 +293,12 @@ namespace MLAPI
         {
             get
             {
-                if (ReferenceEquals(m_NetworkObject, null))
+                if (m_NetworkObject == null)
                 {
                     m_NetworkObject = GetComponentInParent<NetworkObject>();
                 }
 
-                return !ReferenceEquals(m_NetworkObject, null);
+                return m_NetworkObject != null;
             }
         }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -305,7 +305,7 @@ namespace MLAPI
             NetworkSceneManager.SceneNameToIndex.Clear();
             NetworkSceneManager.SceneSwitchProgresses.Clear();
 
-            if (ReferenceEquals(NetworkConfig.NetworkTransport, null))
+            if (NetworkConfig.NetworkTransport == null)
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Error) NetworkLog.LogError("No transport has been selected!");
                 return;
@@ -356,14 +356,14 @@ namespace MLAPI
 
             for (int i = 0; i < NetworkConfig.NetworkPrefabs.Count; i++)
             {
-                if (NetworkConfig.NetworkPrefabs[i] == null || ReferenceEquals(NetworkConfig.NetworkPrefabs[i].Prefab, null))
+                if (NetworkConfig.NetworkPrefabs[i] == null || NetworkConfig.NetworkPrefabs[i].Prefab == null)
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
                         NetworkLog.LogError($"{nameof(NetworkPrefab)} cannot be null ({nameof(NetworkPrefab)} at index: {i})");
                     }
                 }
-                else if (ReferenceEquals(NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>(), null))
+                else if (NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>() == null)
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
@@ -582,7 +582,7 @@ namespace MLAPI
 
         private void OnDestroy()
         {
-            if (!ReferenceEquals(Singleton, null) && Singleton == this)
+            if (Singleton != null && Singleton == this)
             {
                 Shutdown();
                 Singleton = null;
@@ -1118,7 +1118,7 @@ namespace MLAPI
                 var networkObject = NetworkSpawnManager.SpawnedObjects[networkObjectId];
 
                 var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourId);
-                if (ReferenceEquals(networkBehaviour, null)) return;
+                if (networkBehaviour == null) return;
 
                 var rpcParams = new __RpcParams();
                 switch (queueItem.QueueItemType)

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -55,7 +55,7 @@ namespace MLAPI
             {
                 if (OwnerClientIdInternal == null)
                 {
-                    return !ReferenceEquals(NetworkManager.Singleton, null) ? NetworkManager.Singleton.ServerClientId : 0;
+                    return NetworkManager.Singleton != null ? NetworkManager.Singleton.ServerClientId : 0;
                 }
                 else
                 {
@@ -64,7 +64,7 @@ namespace MLAPI
             }
             internal set
             {
-                if (!ReferenceEquals(NetworkManager.Singleton, null) && value == NetworkManager.Singleton.ServerClientId)
+                if (NetworkManager.Singleton != null && value == NetworkManager.Singleton.ServerClientId)
                 {
                     OwnerClientIdInternal = null;
                 }
@@ -114,17 +114,17 @@ namespace MLAPI
         /// <summary>
         /// Gets if the object is the the personal clients player object
         /// </summary>
-        public bool IsLocalPlayer => !ReferenceEquals(NetworkManager.Singleton, null) && IsPlayerObject && OwnerClientId == NetworkManager.Singleton.LocalClientId;
+        public bool IsLocalPlayer => NetworkManager.Singleton != null && IsPlayerObject && OwnerClientId == NetworkManager.Singleton.LocalClientId;
 
         /// <summary>
         /// Gets if the object is owned by the local player or if the object is the local player object
         /// </summary>
-        public bool IsOwner => !ReferenceEquals(NetworkManager.Singleton, null) && OwnerClientId == NetworkManager.Singleton.LocalClientId;
+        public bool IsOwner => NetworkManager.Singleton != null && OwnerClientId == NetworkManager.Singleton.LocalClientId;
 
         /// <summary>
         /// Gets Whether or not the object is owned by anyone
         /// </summary>
-        public bool IsOwnedByServer => !ReferenceEquals(NetworkManager.Singleton, null) && OwnerClientId == NetworkManager.Singleton.ServerClientId;
+        public bool IsOwnedByServer => NetworkManager.Singleton != null && OwnerClientId == NetworkManager.Singleton.ServerClientId;
 
         /// <summary>
         /// Gets if the object has yet been spawned across the network

--- a/com.unity.multiplayer.mlapi/Runtime/Logging/NetworkLog.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Logging/NetworkLog.cs
@@ -15,7 +15,7 @@ namespace MLAPI.Logging
         /// Gets the current log level.
         /// </summary>
         /// <value>The current log level.</value>
-        internal static LogLevel CurrentLogLevel => ReferenceEquals(NetworkManager.Singleton, null) ? LogLevel.Normal : NetworkManager.Singleton.LogLevel;
+        internal static LogLevel CurrentLogLevel => NetworkManager.Singleton == null ? LogLevel.Normal : NetworkManager.Singleton.LogLevel;
 
         // MLAPI internal logging
         internal static void LogInfo(string message) => Debug.Log($"[MLAPI] {message}");

--- a/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
@@ -193,7 +193,7 @@ namespace MLAPI.Serialization
             else if (value is GameObject)
             {
                 var networkObject = ((GameObject)value).GetComponent<NetworkObject>();
-                if (ReferenceEquals(networkObject, null))
+                if (networkObject == null)
                 {
                     throw new ArgumentException($"{nameof(NetworkWriter)} cannot write {nameof(GameObject)} types that does not has a {nameof(NetworkObject)} component attached. {nameof(GameObject)}: {((GameObject)value).name}");
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -262,7 +262,7 @@ namespace MLAPI.Spawning
                 {
                     var networkObject = CustomSpawnHandlers[prefabHash](position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity));
 
-                    if (!ReferenceEquals(parentNetworkObject, null))
+                    if (parentNetworkObject != null)
                     {
                         networkObject.transform.SetParent(parentNetworkObject.transform, true);
                     }
@@ -291,7 +291,7 @@ namespace MLAPI.Spawning
                     var prefab = NetworkManager.Singleton.NetworkConfig.NetworkPrefabs[prefabIndex].Prefab;
                     var networkObject = ((position == null && rotation == null) ? MonoBehaviour.Instantiate(prefab) : MonoBehaviour.Instantiate(prefab, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity))).GetComponent<NetworkObject>();
 
-                    if (!ReferenceEquals(parentNetworkObject, null))
+                    if (parentNetworkObject != null)
                     {
                         networkObject.transform.SetParent(parentNetworkObject.transform, true);
                     }
@@ -320,7 +320,7 @@ namespace MLAPI.Spawning
                 var networkObject = PendingSoftSyncObjects[instanceId];
                 PendingSoftSyncObjects.Remove(instanceId);
 
-                if (!ReferenceEquals(parentNetworkObject, null))
+                if (parentNetworkObject != null)
                 {
                     networkObject.transform.SetParent(parentNetworkObject.transform, true);
                 }
@@ -332,7 +332,7 @@ namespace MLAPI.Spawning
         // Ran on both server and client
         internal static void SpawnNetworkObjectLocally(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, Stream dataStream, bool readPayload, int payloadLength, bool readNetworkVariable, bool destroyWithScene)
         {
-            if (ReferenceEquals(networkObject, null))
+            if (networkObject == null)
             {
                 throw new ArgumentNullException(nameof(networkObject), "Cannot spawn null object");
             }
@@ -447,12 +447,12 @@ namespace MLAPI.Spawning
 
                 NetworkObject parentNetworkObject = null;
 
-                if (!networkObject.AlwaysReplicateAsRoot && !ReferenceEquals(networkObject.transform.parent, null))
+                if (!networkObject.AlwaysReplicateAsRoot && networkObject.transform.parent != null)
                 {
                     parentNetworkObject = networkObject.transform.parent.GetComponent<NetworkObject>();
                 }
 
-                if (ReferenceEquals(parentNetworkObject, null))
+                if (parentNetworkObject == null)
                 {
                     writer.WriteBool(false);
                 }
@@ -652,7 +652,7 @@ namespace MLAPI.Spawning
 
         internal static void OnDestroyObject(ulong networkId, bool destroyGameObject)
         {
-            if (ReferenceEquals(NetworkManager.Singleton, null)) return;
+            if (NetworkManager.Singleton == null) return;
 
             //Removal of spawned object
             if (!SpawnedObjects.ContainsKey(networkId))
@@ -691,7 +691,7 @@ namespace MLAPI.Spawning
                 var rpcQueueContainer = NetworkManager.Singleton.RpcQueueContainer;
                 if (rpcQueueContainer != null)
                 {
-                    if (!ReferenceEquals(sobj, null))
+                    if (sobj != null)
                     {
                         // As long as we have any remaining clients, then notify of the object being destroy.
                         if (NetworkManager.Singleton.ConnectedClientsList.Count > 0)
@@ -720,7 +720,7 @@ namespace MLAPI.Spawning
 
             var gobj = sobj.gameObject;
 
-            if (destroyGameObject && !ReferenceEquals(gobj, null))
+            if (destroyGameObject && gobj != null)
             {
                 if (CustomDestroyHandlers.ContainsKey(sobj.PrefabHash))
                 {


### PR DESCRIPTION
these changes should've been under an isolated PR.
I will attempt to convert them to more performant ones again in the future.