### PR TITLE
fix: unregister NetworkPlayerLoop systems from PlayerLoop

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.LowLevel;
 using UnityEngine.PlayerLoop;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace MLAPI
 {
@@ -237,242 +233,166 @@ namespace MLAPI
             }
         }
 
-        [RuntimeInitializeOnLoadMethod]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Initialize()
         {
-            // for standalone:
-            //      we only `InjectSystems()` into `PlayerLoop` once by `[RuntimeInitializeOnLoadMethod]`
-            //      but we do NOT `UninjectSystems()` since it is not necessary to do so
-            //      because we will exit PlayMode when we quit from the standalone application
-            //
-            // for the editor:
-            //      we do `InjectSystems()` into `PlayerLoop` once by `[RuntimeInitializeOnLoadMethod]`
-            //      and we DO `UninjectSystems()` in the Editor after exiting PlayMode (stop playing)
-            //      because we will still have `PlayerLoop` ticking subsystems until it gets reset again
-
-#if UNITY_EDITOR
-            EditorApplication.playModeStateChanged += stateChange =>
-            {
-                switch (stateChange)
-                {
-                    case PlayModeStateChange.EnteredPlayMode:
-                        InjectSystems();
-                        break;
-                    case PlayModeStateChange.ExitingPlayMode:
-                        UninjectSystems();
-                        break;
-                }
-            };
-#else
-            InjectSystems();
-#endif
+            UnregisterLoopSystems();
+            RegisterLoopSystems();
         }
 
-        internal static void InjectSystems()
+        private enum LoopSystemPosition
         {
-            var customPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
+            After,
+            Before
+        }
 
-            for (int i = 0; i < customPlayerLoop.subSystemList.Length; i++)
+        private static bool TryAddLoopSystem(ref PlayerLoopSystem parentLoopSystem, PlayerLoopSystem childLoopSystem, Type anchorSystemType, LoopSystemPosition loopSystemPosition)
+        {
+            int systemPosition = -1;
+            if (anchorSystemType != null)
             {
-                var playerLoopSystem = customPlayerLoop.subSystemList[i];
-
-                if (playerLoopSystem.type == typeof(Initialization))
+                for (int i = 0; i < parentLoopSystem.subSystemList.Length; i++)
                 {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
+                    var subsystem = parentLoopSystem.subSystemList[i];
+                    if (subsystem.type == anchorSystemType)
                     {
-                        // insert at the bottom of `Initialization`
-                        subsystems.Add(NetworkInitialization.CreateLoopSystem());
+                        systemPosition = loopSystemPosition == LoopSystemPosition.After ? i + 1 : i;
+                        break;
                     }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
                 }
-                else if (playerLoopSystem.type == typeof(EarlyUpdate))
-                {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        int subsystemCount = subsystems.Count;
-                        for (int k = 0; k < subsystemCount; k++)
-                        {
-                            if (subsystems[k].type == typeof(EarlyUpdate.ScriptRunDelayedStartupFrame))
-                            {
-                                // insert before `EarlyUpdate.ScriptRunDelayedStartupFrame`
-                                subsystems.Insert(k, NetworkEarlyUpdate.CreateLoopSystem());
-                                break;
-                            }
-                        }
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(FixedUpdate))
-                {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        int subsystemCount = subsystems.Count;
-                        for (int k = 0; k < subsystemCount; k++)
-                        {
-                            if (subsystems[k].type == typeof(FixedUpdate.ScriptRunBehaviourFixedUpdate))
-                            {
-                                // insert before `FixedUpdate.ScriptRunBehaviourFixedUpdate`
-                                subsystems.Insert(k, NetworkFixedUpdate.CreateLoopSystem());
-                                break;
-                            }
-                        }
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(PreUpdate))
-                {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        int subsystemCount = subsystems.Count;
-                        for (int k = 0; k < subsystemCount; k++)
-                        {
-                            if (subsystems[k].type == typeof(PreUpdate.PhysicsUpdate))
-                            {
-                                // insert before `PreUpdate.PhysicsUpdate`
-                                subsystems.Insert(k, NetworkPreUpdate.CreateLoopSystem());
-                                break;
-                            }
-                        }
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(Update))
-                {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        int subsystemCount = subsystems.Count;
-                        for (int k = 0; k < subsystemCount; k++)
-                        {
-                            if (subsystems[k].type == typeof(Update.ScriptRunBehaviourUpdate))
-                            {
-                                // insert before `Update.ScriptRunBehaviourUpdate`
-                                subsystems.Insert(k, NetworkUpdate.CreateLoopSystem());
-                                break;
-                            }
-                        }
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(PreLateUpdate))
-                {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        int subsystemCount = subsystems.Count;
-                        for (int k = 0; k < subsystemCount; k++)
-                        {
-                            if (subsystems[k].type == typeof(PreLateUpdate.ScriptRunBehaviourLateUpdate))
-                            {
-                                // insert before `PreLateUpdate.ScriptRunBehaviourLateUpdate`
-                                subsystems.Insert(k, NetworkPreLateUpdate.CreateLoopSystem());
-                                break;
-                            }
-                        }
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(PostLateUpdate))
-                {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        int subsystemCount = subsystems.Count;
-                        for (int k = 0; k < subsystemCount; k++)
-                        {
-                            if (subsystems[k].type == typeof(PostLateUpdate.PlayerSendFrameComplete))
-                            {
-                                // insert after `PostLateUpdate.PlayerSendFrameComplete`
-                                subsystems.Insert(k + 1, NetworkPostLateUpdate.CreateLoopSystem());
-                                break;
-                            }
-                        }
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
-                }
-
-                customPlayerLoop.subSystemList[i] = playerLoopSystem;
+            }
+            else
+            {
+                systemPosition = loopSystemPosition == LoopSystemPosition.After ? parentLoopSystem.subSystemList.Length : 0;
             }
 
-            PlayerLoop.SetPlayerLoop(customPlayerLoop);
+            if (systemPosition == -1) return false;
+
+            var newSubsystemList = new PlayerLoopSystem[parentLoopSystem.subSystemList.Length + 1];
+
+            // begin = systemsBefore + systemsAfter
+            // + systemsBefore
+            Array.Copy(parentLoopSystem.subSystemList, newSubsystemList, systemPosition);
+            // + childSystem
+            newSubsystemList[systemPosition] = childLoopSystem;
+            // + systemsAfter
+            Array.Copy(parentLoopSystem.subSystemList, systemPosition, newSubsystemList, systemPosition + 1, parentLoopSystem.subSystemList.Length - systemPosition);
+            // end = systemsBefore + childSystem + systemsAfter
+
+            parentLoopSystem.subSystemList = newSubsystemList;
+
+            return true;
         }
 
-#if UNITY_EDITOR
-        internal static void UninjectSystems()
+        private static bool TryRemoveLoopSystem(ref PlayerLoopSystem parentLoopSystem, Type childSystemType)
         {
-            var customPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
-
-            for (int i = 0; i < customPlayerLoop.subSystemList.Length; i++)
+            int systemPosition = -1;
+            for (int i = 0; i < parentLoopSystem.subSystemList.Length; i++)
             {
-                var playerLoopSystem = customPlayerLoop.subSystemList[i];
-
-                if (playerLoopSystem.type == typeof(Initialization))
+                var subsystem = parentLoopSystem.subSystemList[i];
+                if (subsystem.type == childSystemType)
                 {
-                    playerLoopSystem.subSystemList =
-                        playerLoopSystem.subSystemList
-                            .ToList()
-                            .TryRemoveSystem(typeof(NetworkInitialization))
-                            .ToArray();
+                    systemPosition = i;
+                    break;
                 }
-                else if (playerLoopSystem.type == typeof(EarlyUpdate))
-                {
-                    playerLoopSystem.subSystemList =
-                        playerLoopSystem.subSystemList
-                            .ToList()
-                            .TryRemoveSystem(typeof(NetworkEarlyUpdate))
-                            .ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(FixedUpdate))
-                {
-                    playerLoopSystem.subSystemList =
-                        playerLoopSystem.subSystemList
-                            .ToList()
-                            .TryRemoveSystem(typeof(NetworkFixedUpdate))
-                            .ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(PreUpdate))
-                {
-                    playerLoopSystem.subSystemList =
-                        playerLoopSystem.subSystemList
-                            .ToList()
-                            .TryRemoveSystem(typeof(NetworkPreUpdate))
-                            .ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(Update))
-                {
-                    playerLoopSystem.subSystemList =
-                        playerLoopSystem.subSystemList
-                            .ToList()
-                            .TryRemoveSystem(typeof(NetworkUpdate))
-                            .ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(PreLateUpdate))
-                {
-                    playerLoopSystem.subSystemList =
-                        playerLoopSystem.subSystemList
-                            .ToList()
-                            .TryRemoveSystem(typeof(NetworkPreLateUpdate))
-                            .ToArray();
-                }
-                else if (playerLoopSystem.type == typeof(PostLateUpdate))
-                {
-                    playerLoopSystem.subSystemList =
-                        playerLoopSystem.subSystemList
-                            .ToList()
-                            .TryRemoveSystem(typeof(NetworkPostLateUpdate))
-                            .ToArray();
-                }
-
-                customPlayerLoop.subSystemList[i] = playerLoopSystem;
             }
 
-            PlayerLoop.SetPlayerLoop(customPlayerLoop);
+            if (systemPosition == -1) return false;
+
+            var newSubsystemList = new PlayerLoopSystem[parentLoopSystem.subSystemList.Length - 1];
+
+            // begin = systemsBefore + childSystem + systemsAfter
+            // + systemsBefore
+            Array.Copy(parentLoopSystem.subSystemList, newSubsystemList, systemPosition);
+            // + systemsAfter
+            Array.Copy(parentLoopSystem.subSystemList, systemPosition + 1, newSubsystemList, systemPosition, parentLoopSystem.subSystemList.Length - systemPosition - 1);
+            // end = systemsBefore + systemsAfter
+
+            parentLoopSystem.subSystemList = newSubsystemList;
+
+            return true;
         }
 
-        private static List<PlayerLoopSystem> TryRemoveSystem(this List<PlayerLoopSystem> systemList, Type systemType)
+        internal static void RegisterLoopSystems()
         {
-            int systemIndex = systemList.FindIndex(s => s.type == systemType);
-            if (systemIndex > -1) systemList.RemoveAt(systemIndex);
+            var rootPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
 
-            return systemList;
+            for (int i = 0; i < rootPlayerLoop.subSystemList.Length; i++)
+            {
+                ref var currentSystem = ref rootPlayerLoop.subSystemList[i];
+
+                if (currentSystem.type == typeof(Initialization))
+                {
+                    TryAddLoopSystem(ref currentSystem, NetworkInitialization.CreateLoopSystem(), null, LoopSystemPosition.After);
+                }
+                else if (currentSystem.type == typeof(EarlyUpdate))
+                {
+                    TryAddLoopSystem(ref currentSystem, NetworkEarlyUpdate.CreateLoopSystem(), typeof(EarlyUpdate.ScriptRunDelayedStartupFrame), LoopSystemPosition.Before);
+                }
+                else if (currentSystem.type == typeof(FixedUpdate))
+                {
+                    TryAddLoopSystem(ref currentSystem, NetworkFixedUpdate.CreateLoopSystem(), typeof(FixedUpdate.ScriptRunBehaviourFixedUpdate), LoopSystemPosition.Before);
+                }
+                else if (currentSystem.type == typeof(PreUpdate))
+                {
+                    TryAddLoopSystem(ref currentSystem, NetworkPreUpdate.CreateLoopSystem(), typeof(PreUpdate.PhysicsUpdate), LoopSystemPosition.Before);
+                }
+                else if (currentSystem.type == typeof(Update))
+                {
+                    TryAddLoopSystem(ref currentSystem, NetworkUpdate.CreateLoopSystem(), typeof(Update.ScriptRunBehaviourUpdate), LoopSystemPosition.Before);
+                }
+                else if (currentSystem.type == typeof(PreLateUpdate))
+                {
+                    TryAddLoopSystem(ref currentSystem, NetworkPreLateUpdate.CreateLoopSystem(), typeof(PreLateUpdate.ScriptRunBehaviourLateUpdate), LoopSystemPosition.Before);
+                }
+                else if (currentSystem.type == typeof(PostLateUpdate))
+                {
+                    TryAddLoopSystem(ref currentSystem, NetworkPostLateUpdate.CreateLoopSystem(), typeof(PostLateUpdate.PlayerSendFrameComplete), LoopSystemPosition.After);
+                }
+            }
+
+            PlayerLoop.SetPlayerLoop(rootPlayerLoop);
         }
-#endif
+
+        internal static void UnregisterLoopSystems()
+        {
+            var rootPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
+
+            for (int i = 0; i < rootPlayerLoop.subSystemList.Length; i++)
+            {
+                ref var currentSystem = ref rootPlayerLoop.subSystemList[i];
+
+                if (currentSystem.type == typeof(Initialization))
+                {
+                    TryRemoveLoopSystem(ref currentSystem, typeof(NetworkInitialization));
+                }
+                else if (currentSystem.type == typeof(EarlyUpdate))
+                {
+                    TryRemoveLoopSystem(ref currentSystem, typeof(NetworkEarlyUpdate));
+                }
+                else if (currentSystem.type == typeof(FixedUpdate))
+                {
+                    TryRemoveLoopSystem(ref currentSystem, typeof(NetworkFixedUpdate));
+                }
+                else if (currentSystem.type == typeof(PreUpdate))
+                {
+                    TryRemoveLoopSystem(ref currentSystem, typeof(NetworkPreUpdate));
+                }
+                else if (currentSystem.type == typeof(Update))
+                {
+                    TryRemoveLoopSystem(ref currentSystem, typeof(NetworkUpdate));
+                }
+                else if (currentSystem.type == typeof(PreLateUpdate))
+                {
+                    TryRemoveLoopSystem(ref currentSystem, typeof(NetworkPreLateUpdate));
+                }
+                else if (currentSystem.type == typeof(PostLateUpdate))
+                {
+                    TryRemoveLoopSystem(ref currentSystem, typeof(NetworkPostLateUpdate));
+                }
+            }
+
+            PlayerLoop.SetPlayerLoop(rootPlayerLoop);
+        }
     }
 }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -241,6 +241,16 @@ namespace MLAPI
         [RuntimeInitializeOnLoadMethod]
         private static void Initialize()
         {
+            // for standalone:
+            //      we only `InjectSystems()` into `PlayerLoop` once by `[RuntimeInitializeOnLoadMethod]`
+            //      but we do NOT `UninjectSystems()` since it is not necessary to do so
+            //      because we will exit PlayMode when we quit from the standalone application
+            //
+            // for the editor:
+            //      we do `InjectSystems()` into `PlayerLoop` once by `[RuntimeInitializeOnLoadMethod]`
+            //      and we DO `UninjectSystems()` in the Editor after exiting PlayMode (stop playing)
+            //      because we will still have `PlayerLoop` ticking subsystems until it gets reset again
+
 #if UNITY_EDITOR
             EditorApplication.playModeStateChanged += stateChange =>
             {

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.LowLevel;
 using UnityEngine.PlayerLoop;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace MLAPI
 {
@@ -237,6 +240,16 @@ namespace MLAPI
         [RuntimeInitializeOnLoadMethod]
         private static void Initialize()
         {
+#if UNITY_EDITOR
+            EditorApplication.playModeStateChanged += stateChange =>
+            {
+                if (stateChange == PlayModeStateChange.ExitingPlayMode)
+                {
+                    PlayerLoop.SetPlayerLoop(PlayerLoop.GetDefaultPlayerLoop());
+                }
+            };
+#endif
+
             var customPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
 
             for (int i = 0; i < customPlayerLoop.subSystemList.Length; i++)

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -6,7 +6,6 @@ using UnityEngine.LowLevel;
 using UnityEngine.PlayerLoop;
 #if UNITY_EDITOR
 using UnityEditor;
-
 #endif
 
 namespace MLAPI
@@ -269,7 +268,7 @@ namespace MLAPI
 #endif
         }
 
-        private static void InjectSystems()
+        internal static void InjectSystems()
         {
             var customPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
 
@@ -396,7 +395,7 @@ namespace MLAPI
         }
 
 #if UNITY_EDITOR
-        private static void UninjectSystems()
+        internal static void UninjectSystems()
         {
             var customPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -405,79 +405,73 @@ namespace MLAPI
 
                 if (playerLoopSystem.type == typeof(Initialization))
                 {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        // try to find and remove `NetworkInitialization`
-                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkInitialization));
-                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                    playerLoopSystem.subSystemList =
+                        playerLoopSystem.subSystemList
+                            .ToList()
+                            .TryRemoveSystem(typeof(NetworkInitialization))
+                            .ToArray();
                 }
                 else if (playerLoopSystem.type == typeof(EarlyUpdate))
                 {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        // try to find and remove `NetworkEarlyUpdate`
-                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkEarlyUpdate));
-                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                    playerLoopSystem.subSystemList =
+                        playerLoopSystem.subSystemList
+                            .ToList()
+                            .TryRemoveSystem(typeof(NetworkEarlyUpdate))
+                            .ToArray();
                 }
                 else if (playerLoopSystem.type == typeof(FixedUpdate))
                 {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        // try to find and remove `NetworkFixedUpdate`
-                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkFixedUpdate));
-                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                    playerLoopSystem.subSystemList =
+                        playerLoopSystem.subSystemList
+                            .ToList()
+                            .TryRemoveSystem(typeof(NetworkFixedUpdate))
+                            .ToArray();
                 }
                 else if (playerLoopSystem.type == typeof(PreUpdate))
                 {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        // try to find and remove `NetworkPreUpdate`
-                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkPreUpdate));
-                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                    playerLoopSystem.subSystemList =
+                        playerLoopSystem.subSystemList
+                            .ToList()
+                            .TryRemoveSystem(typeof(NetworkPreUpdate))
+                            .ToArray();
                 }
                 else if (playerLoopSystem.type == typeof(Update))
                 {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        // try to find and remove `NetworkUpdate`
-                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkUpdate));
-                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                    playerLoopSystem.subSystemList =
+                        playerLoopSystem.subSystemList
+                            .ToList()
+                            .TryRemoveSystem(typeof(NetworkUpdate))
+                            .ToArray();
                 }
                 else if (playerLoopSystem.type == typeof(PreLateUpdate))
                 {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        // try to find and remove `NetworkPreLateUpdate`
-                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkPreLateUpdate));
-                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                    playerLoopSystem.subSystemList =
+                        playerLoopSystem.subSystemList
+                            .ToList()
+                            .TryRemoveSystem(typeof(NetworkPreLateUpdate))
+                            .ToArray();
                 }
                 else if (playerLoopSystem.type == typeof(PostLateUpdate))
                 {
-                    var subsystems = playerLoopSystem.subSystemList.ToList();
-                    {
-                        // try to find and remove `NetworkPostLateUpdate`
-                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkPostLateUpdate));
-                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
-                    }
-                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                    playerLoopSystem.subSystemList =
+                        playerLoopSystem.subSystemList
+                            .ToList()
+                            .TryRemoveSystem(typeof(NetworkPostLateUpdate))
+                            .ToArray();
                 }
 
                 customPlayerLoop.subSystemList[i] = playerLoopSystem;
             }
 
             PlayerLoop.SetPlayerLoop(customPlayerLoop);
+        }
+
+        private static List<PlayerLoopSystem> TryRemoveSystem(this List<PlayerLoopSystem> systemList, Type systemType)
+        {
+            int systemIndex = systemList.FindIndex(s => s.type == systemType);
+            if (systemIndex > -1) systemList.RemoveAt(systemIndex);
+
+            return systemList;
         }
 #endif
     }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -6,6 +6,7 @@ using UnityEngine.LowLevel;
 using UnityEngine.PlayerLoop;
 #if UNITY_EDITOR
 using UnityEditor;
+
 #endif
 
 namespace MLAPI
@@ -243,13 +244,23 @@ namespace MLAPI
 #if UNITY_EDITOR
             EditorApplication.playModeStateChanged += stateChange =>
             {
-                if (stateChange == PlayModeStateChange.ExitingPlayMode)
+                switch (stateChange)
                 {
-                    PlayerLoop.SetPlayerLoop(PlayerLoop.GetDefaultPlayerLoop());
+                    case PlayModeStateChange.EnteredPlayMode:
+                        InjectSystems();
+                        break;
+                    case PlayModeStateChange.ExitingPlayMode:
+                        UninjectSystems();
+                        break;
                 }
             };
+#else
+            InjectSystems();
 #endif
+        }
 
+        private static void InjectSystems()
+        {
             var customPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
 
             for (int i = 0; i < customPlayerLoop.subSystemList.Length; i++)
@@ -373,5 +384,92 @@ namespace MLAPI
 
             PlayerLoop.SetPlayerLoop(customPlayerLoop);
         }
+
+#if UNITY_EDITOR
+        private static void UninjectSystems()
+        {
+            var customPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
+
+            for (int i = 0; i < customPlayerLoop.subSystemList.Length; i++)
+            {
+                var playerLoopSystem = customPlayerLoop.subSystemList[i];
+
+                if (playerLoopSystem.type == typeof(Initialization))
+                {
+                    var subsystems = playerLoopSystem.subSystemList.ToList();
+                    {
+                        // try to find and remove `NetworkInitialization`
+                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkInitialization));
+                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
+                    }
+                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                }
+                else if (playerLoopSystem.type == typeof(EarlyUpdate))
+                {
+                    var subsystems = playerLoopSystem.subSystemList.ToList();
+                    {
+                        // try to find and remove `NetworkEarlyUpdate`
+                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkEarlyUpdate));
+                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
+                    }
+                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                }
+                else if (playerLoopSystem.type == typeof(FixedUpdate))
+                {
+                    var subsystems = playerLoopSystem.subSystemList.ToList();
+                    {
+                        // try to find and remove `NetworkFixedUpdate`
+                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkFixedUpdate));
+                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
+                    }
+                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                }
+                else if (playerLoopSystem.type == typeof(PreUpdate))
+                {
+                    var subsystems = playerLoopSystem.subSystemList.ToList();
+                    {
+                        // try to find and remove `NetworkPreUpdate`
+                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkPreUpdate));
+                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
+                    }
+                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                }
+                else if (playerLoopSystem.type == typeof(Update))
+                {
+                    var subsystems = playerLoopSystem.subSystemList.ToList();
+                    {
+                        // try to find and remove `NetworkUpdate`
+                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkUpdate));
+                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
+                    }
+                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                }
+                else if (playerLoopSystem.type == typeof(PreLateUpdate))
+                {
+                    var subsystems = playerLoopSystem.subSystemList.ToList();
+                    {
+                        // try to find and remove `NetworkPreLateUpdate`
+                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkPreLateUpdate));
+                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
+                    }
+                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                }
+                else if (playerLoopSystem.type == typeof(PostLateUpdate))
+                {
+                    var subsystems = playerLoopSystem.subSystemList.ToList();
+                    {
+                        // try to find and remove `NetworkPostLateUpdate`
+                        int systemIndex = subsystems.FindIndex(s => s.type == typeof(NetworkPostLateUpdate));
+                        if (systemIndex > -1) subsystems.RemoveAt(systemIndex);
+                    }
+                    playerLoopSystem.subSystemList = subsystems.ToArray();
+                }
+
+                customPlayerLoop.subSystemList[i] = playerLoopSystem;
+            }
+
+            PlayerLoop.SetPlayerLoop(customPlayerLoop);
+        }
+#endif
     }
 }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkUpdateLoop.cs
@@ -272,11 +272,11 @@ namespace MLAPI
 
             // begin = systemsBefore + systemsAfter
             // + systemsBefore
-            Array.Copy(parentLoopSystem.subSystemList, newSubsystemList, systemPosition);
+            if (systemPosition > 0) Array.Copy(parentLoopSystem.subSystemList, newSubsystemList, systemPosition);
             // + childSystem
             newSubsystemList[systemPosition] = childLoopSystem;
             // + systemsAfter
-            Array.Copy(parentLoopSystem.subSystemList, systemPosition, newSubsystemList, systemPosition + 1, parentLoopSystem.subSystemList.Length - systemPosition);
+            if (systemPosition < parentLoopSystem.subSystemList.Length) Array.Copy(parentLoopSystem.subSystemList, systemPosition, newSubsystemList, systemPosition + 1, parentLoopSystem.subSystemList.Length - systemPosition);
             // end = systemsBefore + childSystem + systemsAfter
 
             parentLoopSystem.subSystemList = newSubsystemList;
@@ -303,9 +303,9 @@ namespace MLAPI
 
             // begin = systemsBefore + childSystem + systemsAfter
             // + systemsBefore
-            Array.Copy(parentLoopSystem.subSystemList, newSubsystemList, systemPosition);
+            if (systemPosition > 0) Array.Copy(parentLoopSystem.subSystemList, newSubsystemList, systemPosition);
             // + systemsAfter
-            Array.Copy(parentLoopSystem.subSystemList, systemPosition + 1, newSubsystemList, systemPosition, parentLoopSystem.subSystemList.Length - systemPosition - 1);
+            if (systemPosition < parentLoopSystem.subSystemList.Length - 1) Array.Copy(parentLoopSystem.subSystemList, systemPosition + 1, newSubsystemList, systemPosition, parentLoopSystem.subSystemList.Length - systemPosition - 1);
             // end = systemsBefore + systemsAfter
 
             parentLoopSystem.subSystemList = newSubsystemList;

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
@@ -17,6 +17,10 @@ namespace MLAPI.RuntimeTests
             // caching the current PlayerLoop (to prevent side-effects on other tests)
             var cachedPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
             {
+                // since current PlayerLoop already took NetworkUpdateLoop systems inside,
+                // we are going to swap it with the default PlayerLoop temporarily for testing
+                PlayerLoop.SetPlayerLoop(PlayerLoop.GetDefaultPlayerLoop());
+
                 NetworkUpdateLoop.RegisterLoopSystems();
 
                 var curPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
@@ -45,6 +49,7 @@ namespace MLAPI.RuntimeTests
                 // since current PlayerLoop already took NetworkUpdateLoop systems inside,
                 // we are going to swap it with the default PlayerLoop temporarily for testing
                 PlayerLoop.SetPlayerLoop(PlayerLoop.GetDefaultPlayerLoop());
+
                 var oldPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
 
                 NetworkUpdateLoop.RegisterLoopSystems();

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkUpdateLoopTests.cs
@@ -12,9 +12,9 @@ namespace MLAPI.RuntimeTests
     public class NetworkUpdateLoopTests
     {
         [UnityTest]
-        public IEnumerator InjectAndUninjectSystems()
+        public IEnumerator RegisterAndUnregisterSystems()
         {
-            // caching the current PlayerLoop (it will have NetworkUpdateLoop systems injected)
+            // caching the current PlayerLoop (it will have NetworkUpdateLoop systems registered)
             var cachedPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
             {
                 // since current PlayerLoop already took NetworkUpdateLoop systems inside,
@@ -22,12 +22,12 @@ namespace MLAPI.RuntimeTests
                 PlayerLoop.SetPlayerLoop(PlayerLoop.GetDefaultPlayerLoop());
                 var oldPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
 
-                NetworkUpdateLoop.InjectSystems();
+                NetworkUpdateLoop.RegisterLoopSystems();
 
                 int waitFrameNumber = Time.frameCount + 8;
                 yield return new WaitUntil(() => Time.frameCount >= waitFrameNumber);
 
-                NetworkUpdateLoop.UninjectSystems();
+                NetworkUpdateLoop.UnregisterLoopSystems();
 
                 var newPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
 
@@ -49,7 +49,7 @@ namespace MLAPI.RuntimeTests
         }
 
         [Test]
-        public void UpdateStageInjection()
+        public void UpdateStageSystems()
         {
             var currentPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
             for (int i = 0; i < currentPlayerLoop.subSystemList.Length; i++)


### PR DESCRIPTION
- implement `UnregisterLoopSystems()` to unregister systems injected into the `PlayerLoop` by the `NetworkUpdateLoop`
- implement a register-then-unregister test to verify `NetworkUpdateLoop` does NOT cause any side-effects on `PlayerLoop`
- refactor for performance (use array ops instead of lists), for better namings (inject → register) and styling (extract duplicate code into helper methods: `TryAddLoopSystem` & `TryRemoveLoopSystem`)