### PR TITLE
fix: Add RequireComponent attribute to NetworkNavMeshAgent.

### DIFF
--- a/com.unity.multiplayer.mlapi/Prototyping/NetworkNavMeshAgent.cs
+++ b/com.unity.multiplayer.mlapi/Prototyping/NetworkNavMeshAgent.cs
@@ -10,6 +10,7 @@ namespace MLAPI.Prototyping
     /// A prototype component for syncing NavMeshAgents
     /// </summary>
     [AddComponentMenu("MLAPI/NetworkNavMeshAgent")]
+    [RequireComponent(typeof(NavMeshAgent))]
     public class NetworkNavMeshAgent : NetworkBehaviour
     {
         private NavMeshAgent m_Agent;


### PR DESCRIPTION
NetworkNavMeshAgent expects a NavMeshAgent and throws a null ref if it's not there. So this attribute should have been there to prevent user error.