### PR TITLE
fix: ServerDestroySpawnedSceneObjects throws an exception before switching scene

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -547,8 +547,8 @@ namespace MLAPI.Spawning
         internal static void ServerDestroySpawnedSceneObjects()
         {
             //This Allocation is "ok" for now because this code only executes when a new scene is switched to
-            //We need to create a new copy the HashSet of NetworkObjects so we can remove objects from the
-            //HashSet without causing a list has been modified exception to occur.
+            //We need to create a new copy the HashSet of NetworkObjects (SpawnedObjectsList) so we can remove
+            //objects from the HashSet (SpawnedObjectsList) without causing a list has been modified exception to occur.
             var spawnedObjects = SpawnedObjectsList.ToList();
             foreach (var sobj in spawnedObjects)
             {

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -541,33 +541,40 @@ namespace MLAPI.Spawning
             }
         }
 
+        /// <summary>
+        /// Gets called only by NetworkSceneManager.SwitchScene
+        /// </summary>
         internal static void ServerDestroySpawnedSceneObjects()
         {
-            List<GameObject> ObjectsToDestroy = new List<GameObject>();
-            List<NetworkObject> CustomObjectsToDestroy = new List<NetworkObject>();
+            //This Allocation is "ok" for now because this code only executes when a new scene is switched to
+            //We need to keep track of GameObjects and NetworkObjects to be destroyed in the current scene
+            //but only destroy them once outside of the enumerative foreach loop
+            var objectsToDestroy = new List<GameObject>();
+            var customObjectsToDestroy = new List<NetworkObject>();
+
             foreach (var sobj in SpawnedObjectsList)
             {
                 if ((sobj.IsSceneObject != null && sobj.IsSceneObject == true) || sobj.DestroyWithScene)
                 {
                     if (CustomDestroyHandlers.ContainsKey(sobj.PrefabHash))
                     {
-                        CustomObjectsToDestroy.Add(sobj);
+                        customObjectsToDestroy.Add(sobj);
 
                     }
                     else
                     {
 
-                        ObjectsToDestroy.Add(sobj.gameObject);
+                        objectsToDestroy.Add(sobj.gameObject);
                     }
                 }
             }
 
-            foreach(var sobj in ObjectsToDestroy)
+            foreach (var sobj in objectsToDestroy)
             {
                 MonoBehaviour.Destroy(sobj.gameObject);
             }
 
-            foreach(var sobj in CustomObjectsToDestroy)
+            foreach (var sobj in customObjectsToDestroy)
             {
                 CustomDestroyHandlers[sobj.PrefabHash](sobj);
                 OnDestroyObject(sobj.NetworkObjectId, false);

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -543,20 +543,34 @@ namespace MLAPI.Spawning
 
         internal static void ServerDestroySpawnedSceneObjects()
         {
+            List<GameObject> ObjectsToDestroy = new List<GameObject>();
+            List<NetworkObject> CustomObjectsToDestroy = new List<NetworkObject>();
             foreach (var sobj in SpawnedObjectsList)
             {
                 if ((sobj.IsSceneObject != null && sobj.IsSceneObject == true) || sobj.DestroyWithScene)
                 {
                     if (CustomDestroyHandlers.ContainsKey(sobj.PrefabHash))
                     {
-                        CustomDestroyHandlers[sobj.PrefabHash](sobj);
-                        OnDestroyObject(sobj.NetworkObjectId, false);
+                        CustomObjectsToDestroy.Add(sobj);
+
                     }
                     else
                     {
-                        MonoBehaviour.Destroy(sobj.gameObject);
+
+                        ObjectsToDestroy.Add(sobj.gameObject);
                     }
                 }
+            }
+
+            foreach(var sobj in ObjectsToDestroy)
+            {
+                MonoBehaviour.Destroy(sobj.gameObject);
+            }
+
+            foreach(var sobj in CustomObjectsToDestroy)
+            {
+                CustomDestroyHandlers[sobj.PrefabHash](sobj);
+                OnDestroyObject(sobj.NetworkObjectId, false);
             }
         }
 


### PR DESCRIPTION
This is the fix for [MTT-544](https://jira.unity3d.com/browse/MTT-544) where transitioning from a scene that has InSceneObjects the Host-Server will throw an exception due to a list in the middle of an enumerative processing loop is modified.

The Jira Bug MTT-544 describes the steps to reproduce the exception and to verify this branch fixes those specific exceptions.