### PR TITLE
ci: target 2019.4 LTS, 2020.3 LTS, 2021.1 TECH, 2021.2 TECH and trunk versions

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -1,10 +1,13 @@
 # Editors where tests will happen. The first entry of this array is also used
-# for validation
+# for validation.
+#
+# Therefore, **do not** put an older V1-lifecycle ver. 
+#  like 2020.x or 2019.x on top of 'test_editors'
 test_editors:
-  - 2019.4
-  - 2020.3
   - 2021.1
   - 2021.2
+  - 2020.3
+  - 2019.4
   - trunk
 
 # Platforms that will be tested. The first entry in this array will also

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -1,8 +1,10 @@
 # Editors where tests will happen. The first entry of this array is also used
 # for validation
 test_editors:
-  - 2021.1
   - 2019.4
+  - 2020.3
+  - 2021.1
+  - 2021.2
   - trunk
 
 # Platforms that will be tested. The first entry in this array will also


### PR DESCRIPTION
as per our internal conversation, now targeting:
- 2019.4 LTS
- 2020.3 LTS
- 2021.1 TECH
- 2021.2 TECH
- trunk