### PR TITLE
fix: use specified transport channel instead of hardcoded reliablerpc channel

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -161,7 +161,7 @@ namespace MLAPI
                     rpcQueueContainer.SetLoopBackFrameItem(clientRpcParams.Send.UpdateStage);
 
                     //Switch to the outbound queue
-                    writer = rpcQueueContainer.BeginAddQueueItemToFrame(RpcQueueContainer.QueueItemType.ClientRpc, Time.realtimeSinceStartup, NetworkChannel.ReliableRpc, NetworkObjectId,
+                    writer = rpcQueueContainer.BeginAddQueueItemToFrame(RpcQueueContainer.QueueItemType.ClientRpc, Time.realtimeSinceStartup, transportChannel, NetworkObjectId,
                         ClientIds, RpcQueueHistoryFrame.QueueFrameType.Outbound, NetworkUpdateStage.PostLateUpdate);
 
                     if (!isUsingBatching)


### PR DESCRIPTION
found this one while running through manual tests.
it occurs if you're running as a Host and trying to replicate an Unreliable ClientRpc (`[ClientRpc(Delivery = RpcDelivery.Unreliable)]`)

I re-did manual tests in various scenarios:
Server + 2 Clients
Host + 1 Client
Client -> ServerRpc -> Server
Server -> ClientRpc -> Clients

they all work fine now — fixes #637.