### PR TITLE
fix: fixed network activity occurring outside the core update getting missed in the profiler

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -652,6 +652,7 @@ namespace MLAPI
 
         private void OnNetworkEarlyUpdate()
         {
+            NotifyProfilerListeners();
             ProfilerBeginTick();
 
             if (IsListening)
@@ -755,8 +756,6 @@ namespace MLAPI
                     m_CurrentNetworkTimeOffset += Mathf.Clamp(m_NetworkTimeOffset - m_CurrentNetworkTimeOffset, -maxDelta, maxDelta);
                 }
             }
-
-            NotifyProfilerListeners();
         }
 
         internal void UpdateNetworkTime(ulong clientId, float netTime, float receiveTime, bool warp = false)


### PR DESCRIPTION
RpcSent, NamedMessagesSent, and UnnamedMessagesSent were broken because they are triggered from the game loop and would not be included in the profiler tick data