### PR TITLE
fix: Resolve an issue where 2019.4 would not properly run ILPP with a clean import

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
@@ -11,8 +11,31 @@ using UnityEngine;
 
 using Assembly = System.Reflection.Assembly;
 
+using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostProcessor;
+
 namespace MLAPI.Editor.CodeGen
 {
+    // There is a behaviour difference between 2019.4 and 2020+ codegen
+    // that essentially does checking on the existence of ILPP vs if a CodeGen assembly
+    // is present. So in order to make sure ILPP runs properly in 2019.4 from a clean
+    // import of the project we add this dummy ILPP which forces the callback to made
+    // and meets the internal ScriptCompilation pipeline requirements
+    internal sealed class HackILPPToMakeThingsWork : ILPPInterface
+    {
+        public override ILPPInterface GetInstance()
+        {
+            return this;
+        }
+
+        public override ILPostProcessResult Process(ICompiledAssembly compiledAssembly)
+        {
+            return null;
+        }
+
+        public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == CodeGenHelpers.RuntimeAssemblyName);
+
+    }
+
     internal static class ILPostProcessProgram
     {
         private static ILPostProcessor[] s_ILPostProcessors { get; set; }

--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/ILPostProcessorProgram.cs
@@ -20,7 +20,7 @@ namespace MLAPI.Editor.CodeGen
     // is present. So in order to make sure ILPP runs properly in 2019.4 from a clean
     // import of the project we add this dummy ILPP which forces the callback to made
     // and meets the internal ScriptCompilation pipeline requirements
-    internal sealed class HackILPPToMakeThingsWork : ILPPInterface
+    internal sealed class ILPP2019CodegenWorkaround : ILPPInterface
     {
         public override ILPPInterface GetInstance()
         {

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/RpcQueueTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/RpcQueueTests.cs
@@ -27,7 +27,6 @@ namespace MLAPI.RuntimeTests
         [UnityTest]
         public IEnumerator RpcQueueUnitTest()
         {
-#if UNITY_2020_2_OR_NEWER // Disabling this test on 2019.4 due to ILPP issues on Yamato CI/CD runs
             var networkManagerObject = new GameObject(nameof(NetworkManager));
             m_NetworkManager = networkManagerObject.AddComponent<NetworkManager>();
             var unetTransport = networkManagerObject.AddComponent<UNetTransport>();
@@ -102,9 +101,6 @@ namespace MLAPI.RuntimeTests
 
             GameObject.DestroyImmediate(playerObject);
             GameObject.DestroyImmediate(networkManagerObject);
-#else
-            yield return null;
-#endif
         }
     }
 }


### PR DESCRIPTION
There is a behavior difference between 2019.4 and 2020+ codegen that essentially does checking on the existence of ILPP vs if a CodeGen assembly is present. So in order to make sure ILPP runs properly in 2019.4 from a clean import of the project we add this dummy ILPP which forces the callback to made and meets the internal ScriptCompilation pipeline requirements.