### PR TITLE
fix: destroy object spam

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -361,7 +361,7 @@ namespace MLAPI
 
         private void OnDestroy()
         {
-            if (NetworkManager.Singleton != null)
+            if (NetworkManager.Singleton != null &&  NetworkSpawnManager.SpawnedObjects.Count > 0 && NetworkSpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
             {
                 NetworkSpawnManager.OnDestroyObject(NetworkObjectId, false);
             }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -361,7 +361,7 @@ namespace MLAPI
 
         private void OnDestroy()
         {
-            if (NetworkManager.Singleton != null &&  NetworkSpawnManager.SpawnedObjects.Count > 0 && NetworkSpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
+            if (NetworkManager.Singleton != null && NetworkSpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
             {
                 NetworkSpawnManager.OnDestroyObject(NetworkObjectId, false);
             }


### PR DESCRIPTION
This fixes an issue where the destroy method can get called twice on the client side after receiving a destroy object command.

This fix is pertaining to [MTT-556](https://jira.unity3d.com/browse/MTT-556)
This is a temporary fix until the spawning and de-spawning process has been fully vetted.
This fix prevents the MonoBehavior.OnDestroy method from invoking the NetworkSpawnManager.OnDestroyObject method if it does not exist in the NetworkSpawnManager.SpawnedObjects list.