### PR TITLE
fix: UNET transport channel UI

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Transports/Tests/Editor/TransportTest.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/Tests/Editor/TransportTest.cs
@@ -38,7 +38,7 @@ public class TransportTest : MonoBehaviour
         byte CustomChannel = 0;
 
         // test 1: add a legit channel.
-        ut.Channels.Add(new UNetChannel { Id = NetworkChannel.ChannelUnused + CustomChannel, Type = QosType.Unreliable });
+        ut.Channels.Add(new UNetChannel { Id = (byte)(NetworkChannel.ChannelUnused + CustomChannel), Type = QosType.Unreliable });
 
         try
         {
@@ -54,7 +54,7 @@ public class TransportTest : MonoBehaviour
 
         ut.Channels.Clear();
         // test 2: add a bogus channel (one that intersects with the MLAPI built-in ones.)  Expect failure
-        ut.Channels.Add(new UNetChannel { Id = NetworkChannel.Internal, Type = QosType.Unreliable });
+        ut.Channels.Add(new UNetChannel { Id = (byte)NetworkChannel.Internal, Type = QosType.Unreliable });
 
         try
         {

--- a/com.unity.multiplayer.mlapi/Runtime/Transports/UNET/UNetChannel.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/UNET/UNetChannel.cs
@@ -1,4 +1,6 @@
 using System;
+using UnityEditor;
+using UnityEngine;
 using UnityEngine.Networking;
 
 namespace MLAPI.Transports
@@ -12,11 +14,33 @@ namespace MLAPI.Transports
         /// <summary>
         /// The name of the channel
         /// </summary>
-        public NetworkChannel Id;
+        [ReadOnly]
+        public byte Id;
 
         /// <summary>
         /// The type of channel
         /// </summary>
         public QosType Type;
+
+        private class ReadOnlyAttribute : PropertyAttribute { }
+
+        [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
+        private class ReadOnlyDrawer : PropertyDrawer
+        {
+            public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+            {
+                // Saving previous GUI enabled value
+                var previousGUIState = GUI.enabled;
+
+                // Disabling edit for property
+                GUI.enabled = false;
+
+                // Drawing Property
+                EditorGUI.PropertyField(position, property, label);
+
+                // Setting old GUI enabled value
+                GUI.enabled = previousGUIState;
+            }
+        }
     }
 }

--- a/com.unity.multiplayer.mlapi/Runtime/Transports/UNET/UNetChannel.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/UNET/UNetChannel.cs
@@ -1,5 +1,7 @@
 using System;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -14,7 +16,9 @@ namespace MLAPI.Transports
         /// <summary>
         /// The name of the channel
         /// </summary>
+        #if UNITY_EDITOR
         [ReadOnly]
+        #endif
         public byte Id;
 
         /// <summary>
@@ -22,6 +26,7 @@ namespace MLAPI.Transports
         /// </summary>
         public QosType Type;
 
+        #if UNITY_EDITOR
         private class ReadOnlyAttribute : PropertyAttribute { }
 
         [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
@@ -42,5 +47,6 @@ namespace MLAPI.Transports
                 GUI.enabled = previousGUIState;
             }
         }
+        #endif
     }
 }

--- a/com.unity.multiplayer.mlapi/Runtime/Transports/UNET/UNetTransport.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/UNET/UNetTransport.cs
@@ -64,6 +64,15 @@ namespace MLAPI.Transports.UNET
         private SocketTask m_ConnectTask;
         public override ulong ServerClientId => GetMLAPIClientId(0, 0, true);
 
+        private void OnValidate()
+        {
+            for (int i = 0; i < Channels.Count; i++)
+            {
+                // Set the channels to a incrementing value
+                Channels[i].Id = (byte)((byte) NetworkChannel.ChannelUnused + i);
+            }
+        }
+
         protected void LateUpdate()
         {
             if (UnityEngine.Networking.NetworkTransport.IsStarted && MessageSendMode == SendMode.Queued)
@@ -392,13 +401,13 @@ namespace MLAPI.Transports.UNET
             {
                 int channelId = AddUNETChannel(Channels[i].Type, connectionConfig);
 
-                if (m_ChannelNameToId.ContainsKey(Channels[i].Id))
+                if (m_ChannelNameToId.ContainsKey((NetworkChannel)Channels[i].Id))
                 {
                     throw new InvalidChannelException($"Channel {channelId} already exists");
                 }
 
-                m_ChannelIdToName.Add(channelId, Channels[i].Id);
-                m_ChannelNameToId.Add(Channels[i].Id, channelId);
+                m_ChannelIdToName.Add(channelId, (NetworkChannel)Channels[i].Id);
+                m_ChannelNameToId.Add((NetworkChannel)Channels[i].Id, channelId);
             }
 
             connectionConfig.MaxSentMessageQueueSize = (ushort)MaxSentMessageQueueSize;

--- a/com.unity.multiplayer.mlapi/Runtime/Transports/UNET/UNetTransport.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/UNET/UNetTransport.cs
@@ -64,6 +64,7 @@ namespace MLAPI.Transports.UNET
         private SocketTask m_ConnectTask;
         public override ulong ServerClientId => GetMLAPIClientId(0, 0, true);
 
+        #if UNITY_EDITOR
         private void OnValidate()
         {
             for (int i = 0; i < Channels.Count; i++)
@@ -72,6 +73,7 @@ namespace MLAPI.Transports.UNET
                 Channels[i].Id = (byte)((byte) NetworkChannel.ChannelUnused + i);
             }
         }
+        #endif
 
         protected void LateUpdate()
         {


### PR DESCRIPTION
This PR fixes the issue where you were unable to create custom channels from UI.

![image](https://user-images.githubusercontent.com/21089228/112945359-b450a900-9123-11eb-8ffa-1feb23e02640.png)

When you add a channel it will autogenerate an ID. If you then want to use it in the API you have to take that byte and convert it to NetworkChannel. E.g ``myNetVar.Channel = (NetworkChannel)11``