### PR TITLE
feat!: add client id to spawn handler

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -1446,7 +1446,7 @@ namespace MLAPI
 
                 if (createPlayerObject)
                 {
-                    var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(false, 0, playerPrefabHash ?? NetworkConfig.PlayerPrefabHash.Value, null, position, rotation);
+                    var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(false, 0, playerPrefabHash ?? NetworkConfig.PlayerPrefabHash.Value, clientId, null, position, rotation);
                     NetworkSpawnManager.SpawnNetworkObjectLocally(networkObject, NetworkSpawnManager.GetNetworkObjectId(), false, true, clientId, null, false, 0, false, false);
 
                     ConnectedClients[clientId].PlayerObject = networkObject;

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -166,7 +166,7 @@ namespace MLAPI.Messaging
                                 rot = Quaternion.Euler(continuationReader.ReadSinglePacked(), continuationReader.ReadSinglePacked(), continuationReader.ReadSinglePacked());
                             }
 
-                            var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(softSync, instanceId, prefabHash, parentNetworkId, pos, rot);
+                            var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(softSync, instanceId, prefabHash, ownerId, parentNetworkId, pos, rot);
                             NetworkSpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerId, continuationStream, false, 0, true, false);
 
                             Queue<BufferManager.BufferedMessage> bufferQueue = BufferManager.ConsumeBuffersForNetworkId(networkId);
@@ -273,7 +273,7 @@ namespace MLAPI.Messaging
                 bool hasPayload = reader.ReadBool();
                 int payLoadLength = hasPayload ? reader.ReadInt32Packed() : 0;
 
-                var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(softSync, instanceId, prefabHash, parentNetworkId, pos, rot);
+                var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(softSync, instanceId, prefabHash, ownerId, parentNetworkId, pos, rot);
                 NetworkSpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerId, stream, hasPayload, payLoadLength, true, false);
 
                 Queue<BufferManager.BufferedMessage> bufferQueue = BufferManager.ConsumeBuffersForNetworkId(networkId);

--- a/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -366,7 +366,7 @@ namespace MLAPI.SceneManagement
                             rotation = Quaternion.Euler(reader.ReadSinglePacked(), reader.ReadSinglePacked(), reader.ReadSinglePacked());
                         }
 
-                        var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(false, 0, prefabHash, parentNetworkId, position, rotation);
+                        var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(false, 0, prefabHash, owner, parentNetworkId, position, rotation);
                         NetworkSpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, true, isPlayerObject, owner, objectStream, false, 0, true, false);
 
                         var bufferQueue = BufferManager.ConsumeBuffersForNetworkId(networkId);
@@ -408,7 +408,7 @@ namespace MLAPI.SceneManagement
 
                         ulong instanceId = reader.ReadUInt64Packed();
 
-                        var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(true, instanceId, 0, parentNetworkId, null, null);
+                        var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(true, instanceId, 0, owner, parentNetworkId, null, null);
                         NetworkSpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, true, isPlayerObject, owner, objectStream, false, 0, true, false);
 
                         var bufferQueue = BufferManager.ConsumeBuffersForNetworkId(networkId);

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -37,7 +37,7 @@ namespace MLAPI.Spawning
         /// </summary>
         /// <param name="position">The position to spawn the object at</param>
         /// <param name="rotation">The rotation to spawn the object with</param>
-        public delegate NetworkObject SpawnHandlerDelegate(Vector3 position, Quaternion rotation);
+        public delegate NetworkObject SpawnHandlerDelegate(ulong clientId, Vector3 position, Quaternion rotation);
 
         /// <summary>
         /// The delegate used when destroying NetworkObjects
@@ -250,7 +250,7 @@ namespace MLAPI.Spawning
         }
 
         // Only ran on Client
-        internal static NetworkObject CreateLocalNetworkObject(bool softCreate, ulong instanceId, ulong prefabHash, ulong? parentNetworkId, Vector3? position, Quaternion? rotation)
+        internal static NetworkObject CreateLocalNetworkObject(bool softCreate, ulong instanceId, ulong prefabHash, ulong clientId, ulong? parentNetworkId, Vector3? position, Quaternion? rotation)
         {
             NetworkObject parentNetworkObject = null;
 
@@ -271,7 +271,7 @@ namespace MLAPI.Spawning
                 // Create the object
                 if (CustomSpawnHandlers.ContainsKey(prefabHash))
                 {
-                    var networkObject = CustomSpawnHandlers[prefabHash](position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity));
+                    var networkObject = CustomSpawnHandlers[prefabHash](clientId, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity));
 
                     if (parentNetworkObject != null)
                     {


### PR DESCRIPTION
This PR adds the owner's client id to the spawn handler. This is used for determining if an object is being instantiated on the owner's computer or a remote user is being instantiated on the local computer. It is also useful in deciding where a player object should spawn based on who that user it is.