### PR TITLE
refactor!: make NetworkObject's NetworkInstanceId property internal

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/AssemblyInfo.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/AssemblyInfo.cs
@@ -4,4 +4,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.EditorTests")]
 [assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.RuntimeTests")]
 [assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor.CodeGen")]
+[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor")]
 #endif

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -84,7 +84,7 @@ namespace MLAPI
         /// </summary>
         [HideInInspector]
         [SerializeField]
-        public ulong NetworkInstanceId;
+        internal ulong NetworkInstanceId;
 
         /// <summary>
         /// The Prefab unique hash. This should not be set my the user but rather changed by editing the PrefabHashGenerator.


### PR DESCRIPTION
this is a breaking change!
however, `NetworkInstanceId` is being used in just a few places and there is no strong reason to expose it to public.
it's more of an implementation detail that serves a purpose for identification of networkobjects placed into the scene.