### PR TITLE
fix: more stable profiler stats. Averages over a full second. 

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Profiling/ProfilerStat.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Profiling/ProfilerStat.cs
@@ -1,14 +1,7 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace MLAPI.Profiling
 {
-    public struct Sample
-    {
-        public int Count;
-        public float TimeRecorded;
-    }
-
     public class ProfilerStat
     {
         public ProfilerStat(string name)
@@ -18,67 +11,28 @@ namespace MLAPI.Profiling
         }
 
         public string PrettyPrintName;
-        protected int m_MaxSamples = 10;
 
-        protected LinkedList<Sample> m_Data = new LinkedList<Sample>();
-
-        private bool m_IsDirty = true;
-
-        protected float m_LastCount;
-        protected float m_LastTime;
+        private int m_CurrentSecond = 0;
+        private int m_TotalAmount = 0;
+        private int m_Sample = 0;
 
         public virtual void Record(int amt = 1)
         {
-            m_IsDirty = true;
-            var timeNow = Time.time;
-            // 'Record' can get called many times in the same frame (for the same exact timestamp)
-            //   This not only blows out the samples but makes the rate computation break since we 
-            //   have n samples with a time delta of zero.
-            // 
-            //   Instead, if we want to record a value at the same exact time as our last
-            //   sample, just adjust that sample
-            if (m_Data.First != null && m_Data.First.Value.TimeRecorded == timeNow)
+            int currentSecond = (int)Time.unscaledTime;
+            if (currentSecond != m_CurrentSecond)
             {
-                m_Data.First.Value = new Sample()
-                {
-                    Count = m_Data.First.Value.Count + amt,
-                    TimeRecorded = m_Data.First.Value.TimeRecorded
-                };
+                m_Sample = m_TotalAmount;
+
+                m_TotalAmount = 0;
+                m_CurrentSecond = currentSecond;
             }
-            else
-            {
-                m_Data.AddFirst(new Sample() { Count = amt, TimeRecorded = Time.time });
-                while (m_Data.Count > m_MaxSamples)
-                {
-                    m_Data.RemoveLast();
-                }
-            }
+
+            m_TotalAmount += amt;
         }
 
         public virtual float SampleRate()
         {
-            if (m_IsDirty)
-            {
-                LinkedListNode<Sample> node = m_Data.First;
-                m_LastCount = 0;
-                m_LastTime = m_Data.Last?.Value.TimeRecorded ?? 0.0f;
-
-                while (node != null)
-                {
-                    m_LastCount += node.Value.Count;
-                    node = node.Next;
-                }
-
-                m_IsDirty = false;
-            }
-
-            float delta = Time.time - m_LastTime;
-            if (delta == 0.0f)
-            {
-                return 0.0f;
-            }
-
-            return m_LastCount / delta;
+            return m_Sample;
         }
     }
 
@@ -90,12 +44,6 @@ namespace MLAPI.Profiling
 
         public override void Record(int amt = 1)
         {
-            m_Data.AddFirst(new Sample() { Count = amt, TimeRecorded = Time.time });
-            while (m_Data.Count > m_MaxSamples)
-            {
-                m_Data.RemoveLast();
-            }
-
             m_InternalValue += amt;
         }
 


### PR DESCRIPTION
Also removes memory allocations, which is good for performance.

Before this change, the profiler stats are noisy, very dependant on when they are sampled. With this change, they become less so.  See comparison below on the same run (measuring the "send bytes" over 40 seconds at 400 cubes per second in scale-demo project)

Before
![chart_before](https://user-images.githubusercontent.com/24359051/113156499-0d920880-9208-11eb-91b2-25e24d4b7e79.png)

After
![chart_after](https://user-images.githubusercontent.com/24359051/113156563-1a166100-9208-11eb-8363-54174a278238.png)
