### PR TITLE
refactor: remove FormerlySerializedAs attribute from NetworkPrefabs field

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -53,7 +53,6 @@ namespace MLAPI.Configuration
         /// A list of spawnable prefabs
         /// </summary>
         [Tooltip("The prefabs that can be spawned across the network")]
-        [FormerlySerializedAs("NetworkedPrefabs")]
         public List<NetworkPrefab> NetworkPrefabs = new List<NetworkPrefab>();
 
         /// <summary>


### PR DESCRIPTION
we wanted to keep this mainly for MLAPI to MLAPI-0.1.0 upgrade.
however, this is probably no longer needed for the pre-1.0.0 release.