### PR TITLE
docs: Fix MIT license hyperlink in the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,3 @@ public class Chat : NetworkBehaviour
     }
 }
 ```
-
-### License
-[MIT License](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ public class Chat : NetworkBehaviour
 ```
 
 ### License
-[MIT License](LICENSE)
+[MIT License](LICENSE.md)


### PR DESCRIPTION
A dear Discord User has noticed that the MIT License hyperlink in the main README.md redirects users to a 404 page, this pull request addresses that issue.