### PR TITLE
feat!: Network Prefab Overrides, Inspector View, and the default Player Prefab

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
@@ -188,7 +188,7 @@ namespace MLAPI.Editor
                 var networkOverrideInt = networkOverrideProp.enumValueIndex;
                 var networkOverrideEnum = (NetworkPrefabOverride)networkOverrideInt;
                 EditorGUI.LabelField(new Rect(rect.x + rect.width - 70, rect.y, 60, EditorGUIUtility.singleLineHeight), "Override");
-                if (networkOverrideEnum == NetworkPrefabOverride.Unset)
+                if (networkOverrideEnum == NetworkPrefabOverride.None)
                 {
                     if (EditorGUI.Toggle(new Rect(rect.x + rect.width - 15, rect.y, 10, EditorGUIUtility.singleLineHeight), false))
                     {
@@ -200,11 +200,11 @@ namespace MLAPI.Editor
                     if (!EditorGUI.Toggle(new Rect(rect.x + rect.width - 15, rect.y, 10, EditorGUIUtility.singleLineHeight), true))
                     {
                         networkOverrideProp.enumValueIndex = 0;
-                        networkOverrideEnum = NetworkPrefabOverride.Unset;
+                        networkOverrideEnum = NetworkPrefabOverride.None;
                     }
                 }
 
-                if (networkOverrideEnum == NetworkPrefabOverride.Unset)
+                if (networkOverrideEnum == NetworkPrefabOverride.None)
                 {
                     EditorGUI.PropertyField(new Rect(rect.x, rect.y, rect.width - 80, EditorGUIUtility.singleLineHeight), networkPrefabProp, GUIContent.none);
                 }

--- a/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
@@ -117,7 +117,6 @@ namespace MLAPI.Editor
             m_EnsureNetworkVariableLengthSafetyProperty = m_NetworkConfigProperty.FindPropertyRelative("EnsureNetworkVariableLengthSafety");
             m_CreatePlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative("CreatePlayerPrefab");
             m_ForceSamePrefabsProperty = m_NetworkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
-            m_UsePrefabSyncProperty = m_NetworkConfigProperty.FindPropertyRelative("UsePrefabSync");
             m_EnableSceneManagementProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableSceneManagement");
             m_RecycleNetworkIdsProperty = m_NetworkConfigProperty.FindPropertyRelative("RecycleNetworkIds");
             m_NetworkIdRecycleDelayProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkIdRecycleDelay");
@@ -137,7 +136,7 @@ namespace MLAPI.Editor
             m_RunInBackgroundProperty = serializedObject.FindProperty(nameof(NetworkManager.RunInBackground));
             m_LogLevelProperty = serializedObject.FindProperty(nameof(NetworkManager.LogLevel));
             m_NetworkConfigProperty = serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig));
-
+            
             // NetworkConfig properties
             m_PlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative(nameof(NetworkConfig.PlayerPrefab));
             m_ProtocolVersionProperty = m_NetworkConfigProperty.FindPropertyRelative("ProtocolVersion");

--- a/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
@@ -36,9 +36,7 @@ namespace MLAPI.Editor
         private SerializedProperty m_TimeResyncIntervalProperty;
         private SerializedProperty m_EnableNetworkVariableProperty;
         private SerializedProperty m_EnsureNetworkVariableLengthSafetyProperty;
-        private SerializedProperty m_CreatePlayerPrefabProperty;
-        private SerializedProperty m_ForceSamePrefabsProperty;
-        private SerializedProperty m_UsePrefabSyncProperty;
+        private SerializedProperty m_ForceSamePrefabsProperty;        
         private SerializedProperty m_EnableSceneManagementProperty;
         private SerializedProperty m_RecycleNetworkIdsProperty;
         private SerializedProperty m_NetworkIdRecycleDelayProperty;
@@ -114,8 +112,7 @@ namespace MLAPI.Editor
             m_EnableTimeResyncProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableTimeResync");
             m_TimeResyncIntervalProperty = m_NetworkConfigProperty.FindPropertyRelative("TimeResyncInterval");
             m_EnableNetworkVariableProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableNetworkVariable");
-            m_EnsureNetworkVariableLengthSafetyProperty = m_NetworkConfigProperty.FindPropertyRelative("EnsureNetworkVariableLengthSafety");
-            m_CreatePlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative("CreatePlayerPrefab");
+            m_EnsureNetworkVariableLengthSafetyProperty = m_NetworkConfigProperty.FindPropertyRelative("EnsureNetworkVariableLengthSafety");            
             m_ForceSamePrefabsProperty = m_NetworkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
             m_EnableSceneManagementProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableSceneManagement");
             m_RecycleNetworkIdsProperty = m_NetworkConfigProperty.FindPropertyRelative("RecycleNetworkIds");
@@ -152,7 +149,6 @@ namespace MLAPI.Editor
             m_TimeResyncIntervalProperty = m_NetworkConfigProperty.FindPropertyRelative("TimeResyncInterval");
             m_EnableNetworkVariableProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableNetworkVariable");
             m_EnsureNetworkVariableLengthSafetyProperty = m_NetworkConfigProperty.FindPropertyRelative("EnsureNetworkVariableLengthSafety");
-            m_CreatePlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative("CreatePlayerPrefab");
             m_ForceSamePrefabsProperty = m_NetworkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
             m_EnableSceneManagementProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableSceneManagement");
             m_RecycleNetworkIdsProperty = m_NetworkConfigProperty.FindPropertyRelative("RecycleNetworkIds");
@@ -341,7 +337,6 @@ namespace MLAPI.Editor
                 }
 
                 EditorGUILayout.LabelField("Spawning", EditorStyles.boldLabel);
-                EditorGUILayout.PropertyField(m_CreatePlayerPrefabProperty);
                 EditorGUILayout.PropertyField(m_ForceSamePrefabsProperty);
 
 

--- a/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
@@ -180,8 +180,8 @@ namespace MLAPI.Editor
 
                 var networkPrefab = m_NetworkPrefabsList.serializedProperty.GetArrayElementAtIndex(index);
                 var networkPrefabProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.Prefab));
-                var networkSourceHashProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.OverridingSourceHash));
-                var networkSourcePrefabProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.OverridingSourcePrefab));
+                var networkSourceHashProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.SourceHashToOverride));
+                var networkSourcePrefabProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.SourcePrefabToOverride));
                 var networkTargetPrefabProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.OverridingTargetPrefab));
                 var networkOverrideProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.Override));
                 var networkOverrideInt = networkOverrideProp.enumValueIndex;

--- a/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkManagerEditor.cs
@@ -3,423 +3,442 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using UnityEditorInternal;
-using MLAPI;
 using MLAPI.Configuration;
 using MLAPI.Transports;
 
-[CustomEditor(typeof(NetworkManager), true)]
-[CanEditMultipleObjects]
-public class NetworkManagerEditor : Editor
+namespace MLAPI.Editor
 {
-    // Properties
-    private SerializedProperty m_DontDestroyOnLoadProperty;
-    private SerializedProperty m_RunInBackgroundProperty;
-    private SerializedProperty m_LogLevelProperty;
-
-    // NetworkConfig
-    private SerializedProperty m_NetworkConfigProperty;
-
-    // NetworkConfig fields
-    private SerializedProperty m_ProtocolVersionProperty;
-    private SerializedProperty m_AllowRuntimeSceneChangesProperty;
-    private SerializedProperty m_NetworkTransportProperty;
-    private SerializedProperty m_ReceiveTickrateProperty;
-    private SerializedProperty m_NetworkTickIntervalSecProperty;
-    private SerializedProperty m_MaxReceiveEventsPerTickRateProperty;
-    private SerializedProperty m_EventTickrateProperty;
-    private SerializedProperty m_MaxObjectUpdatesPerTickProperty;
-    private SerializedProperty m_ClientConnectionBufferTimeoutProperty;
-    private SerializedProperty m_ConnectionApprovalProperty;
-    private SerializedProperty m_EnableTimeResyncProperty;
-    private SerializedProperty m_TimeResyncIntervalProperty;
-    private SerializedProperty m_EnableNetworkVariableProperty;
-    private SerializedProperty m_EnsureNetworkVariableLengthSafetyProperty;
-    private SerializedProperty m_CreatePlayerPrefabProperty;
-    private SerializedProperty m_ForceSamePrefabsProperty;
-    private SerializedProperty m_EnableSceneManagementProperty;
-    private SerializedProperty m_RecycleNetworkIdsProperty;
-    private SerializedProperty m_NetworkIdRecycleDelayProperty;
-    private SerializedProperty m_RpcHashSizeProperty;
-    private SerializedProperty m_LoadSceneTimeOutProperty;
-    private SerializedProperty m_EnableMessageBufferingProperty;
-    private SerializedProperty m_MessageBufferTimeoutProperty;
-
-    private ReorderableList m_NetworkPrefabsList;
-    private ReorderableList m_RegisteredScenesList;
-
-    private NetworkManager m_NetworkManager;
-    private bool m_Initialized;
-
-    private readonly List<Type> m_TransportTypes = new List<Type>();
-    private string[] m_TransportNames = { "Select transport..." };
-
-    private void ReloadTransports()
+    [CustomEditor(typeof(NetworkManager), true)]
+    [CanEditMultipleObjects]
+    public class NetworkManagerEditor : UnityEditor.Editor
     {
-        m_TransportTypes.Clear();
+        // Properties
+        private SerializedProperty m_DontDestroyOnLoadProperty;
+        private SerializedProperty m_RunInBackgroundProperty;
+        private SerializedProperty m_LogLevelProperty;
 
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        // NetworkConfig
+        private SerializedProperty m_NetworkConfigProperty;
 
-        foreach (var assembly in assemblies)
+        // NetworkConfig fields
+        private SerializedProperty m_PlayerPrefabProperty;
+        private SerializedProperty m_ProtocolVersionProperty;
+        private SerializedProperty m_AllowRuntimeSceneChangesProperty;
+        private SerializedProperty m_NetworkTransportProperty;
+        private SerializedProperty m_ReceiveTickrateProperty;
+        private SerializedProperty m_NetworkTickIntervalSecProperty;
+        private SerializedProperty m_MaxReceiveEventsPerTickRateProperty;
+        private SerializedProperty m_EventTickrateProperty;
+        private SerializedProperty m_MaxObjectUpdatesPerTickProperty;
+        private SerializedProperty m_ClientConnectionBufferTimeoutProperty;
+        private SerializedProperty m_ConnectionApprovalProperty;
+        private SerializedProperty m_EnableTimeResyncProperty;
+        private SerializedProperty m_TimeResyncIntervalProperty;
+        private SerializedProperty m_EnableNetworkVariableProperty;
+        private SerializedProperty m_EnsureNetworkVariableLengthSafetyProperty;
+        private SerializedProperty m_CreatePlayerPrefabProperty;
+        private SerializedProperty m_ForceSamePrefabsProperty;
+        private SerializedProperty m_UsePrefabSyncProperty;
+        private SerializedProperty m_EnableSceneManagementProperty;
+        private SerializedProperty m_RecycleNetworkIdsProperty;
+        private SerializedProperty m_NetworkIdRecycleDelayProperty;
+        private SerializedProperty m_RpcHashSizeProperty;
+        private SerializedProperty m_LoadSceneTimeOutProperty;
+        private SerializedProperty m_EnableMessageBufferingProperty;
+        private SerializedProperty m_MessageBufferTimeoutProperty;
+
+        private ReorderableList m_NetworkPrefabsList;
+        private ReorderableList m_RegisteredScenesList;
+
+        private NetworkManager m_NetworkManager;
+        private bool m_Initialized;
+
+        private readonly List<Type> m_TransportTypes = new List<Type>();
+        private string[] m_TransportNames = { "Select transport..." };
+
+        private void ReloadTransports()
         {
-            var types = assembly.GetTypes();
+            m_TransportTypes.Clear();
 
-            foreach (var type in types)
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
             {
-                if (type.IsSubclassOf(typeof(NetworkTransport)))
+                var types = assembly.GetTypes();
+
+                foreach (var type in types)
                 {
-                    m_TransportTypes.Add(type);
+                    if (type.IsSubclassOf(typeof(NetworkTransport)))
+                    {
+                        m_TransportTypes.Add(type);
+                    }
                 }
+            }
+
+            m_TransportNames = new string[m_TransportTypes.Count + 1];
+            m_TransportNames[0] = "Select transport...";
+
+            for (int i = 0; i < m_TransportTypes.Count; i++)
+            {
+                m_TransportNames[i + 1] = m_TransportTypes[i].Name;
             }
         }
 
-        m_TransportNames = new string[m_TransportTypes.Count + 1];
-        m_TransportNames[0] = "Select transport...";
-
-        for (int i = 0; i < m_TransportTypes.Count; i++)
+        private void Initialize()
         {
-            m_TransportNames[i + 1] = m_TransportTypes[i].Name;
-        }
-    }
-
-    private void Init()
-    {
-        if (m_Initialized)
-        {
-            return;
-        }
-
-        m_Initialized = true;
-        m_NetworkManager = (NetworkManager)target;
-
-        // Base properties
-        m_DontDestroyOnLoadProperty = serializedObject.FindProperty(nameof(NetworkManager.DontDestroy));
-        m_RunInBackgroundProperty = serializedObject.FindProperty(nameof(NetworkManager.RunInBackground));
-        m_LogLevelProperty = serializedObject.FindProperty(nameof(NetworkManager.LogLevel));
-        m_NetworkConfigProperty = serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig));
-
-        // NetworkConfig properties
-        m_ProtocolVersionProperty = m_NetworkConfigProperty.FindPropertyRelative("ProtocolVersion");
-        m_AllowRuntimeSceneChangesProperty = m_NetworkConfigProperty.FindPropertyRelative("AllowRuntimeSceneChanges");
-        m_NetworkTransportProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTransport");
-        m_ReceiveTickrateProperty = m_NetworkConfigProperty.FindPropertyRelative("ReceiveTickrate");
-        m_NetworkTickIntervalSecProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTickIntervalSec");
-        m_MaxReceiveEventsPerTickRateProperty = m_NetworkConfigProperty.FindPropertyRelative("MaxReceiveEventsPerTickRate");
-        m_EventTickrateProperty = m_NetworkConfigProperty.FindPropertyRelative("EventTickrate");
-        m_ClientConnectionBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
-        m_ConnectionApprovalProperty = m_NetworkConfigProperty.FindPropertyRelative("ConnectionApproval");
-        m_EnableTimeResyncProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableTimeResync");
-        m_TimeResyncIntervalProperty = m_NetworkConfigProperty.FindPropertyRelative("TimeResyncInterval");
-        m_EnableNetworkVariableProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableNetworkVariable");
-        m_EnsureNetworkVariableLengthSafetyProperty = m_NetworkConfigProperty.FindPropertyRelative("EnsureNetworkVariableLengthSafety");
-        m_CreatePlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative("CreatePlayerPrefab");
-        m_ForceSamePrefabsProperty = m_NetworkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
-        m_EnableSceneManagementProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableSceneManagement");
-        m_RecycleNetworkIdsProperty = m_NetworkConfigProperty.FindPropertyRelative("RecycleNetworkIds");
-        m_NetworkIdRecycleDelayProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkIdRecycleDelay");
-        m_RpcHashSizeProperty = m_NetworkConfigProperty.FindPropertyRelative("RpcHashSize");
-        m_LoadSceneTimeOutProperty = m_NetworkConfigProperty.FindPropertyRelative("LoadSceneTimeOut");
-        m_EnableMessageBufferingProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableMessageBuffering");
-        m_MessageBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("MessageBufferTimeout");
-
-
-        ReloadTransports();
-    }
-
-    private void CheckNullProperties()
-    {
-        // Base properties
-        m_DontDestroyOnLoadProperty = serializedObject.FindProperty(nameof(NetworkManager.DontDestroy));
-        m_RunInBackgroundProperty = serializedObject.FindProperty(nameof(NetworkManager.RunInBackground));
-        m_LogLevelProperty = serializedObject.FindProperty(nameof(NetworkManager.LogLevel));
-        m_NetworkConfigProperty = serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig));
-
-        // NetworkConfig properties
-        m_ProtocolVersionProperty = m_NetworkConfigProperty.FindPropertyRelative("ProtocolVersion");
-        m_AllowRuntimeSceneChangesProperty = m_NetworkConfigProperty.FindPropertyRelative("AllowRuntimeSceneChanges");
-        m_NetworkTransportProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTransport");
-        m_ReceiveTickrateProperty = m_NetworkConfigProperty.FindPropertyRelative("ReceiveTickrate");
-        m_NetworkTickIntervalSecProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTickIntervalSec");
-        m_MaxReceiveEventsPerTickRateProperty = m_NetworkConfigProperty.FindPropertyRelative("MaxReceiveEventsPerTickRate");
-        m_EventTickrateProperty = m_NetworkConfigProperty.FindPropertyRelative("EventTickrate");
-        m_ClientConnectionBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
-        m_ConnectionApprovalProperty = m_NetworkConfigProperty.FindPropertyRelative("ConnectionApproval");
-        m_EnableTimeResyncProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableTimeResync");
-        m_TimeResyncIntervalProperty = m_NetworkConfigProperty.FindPropertyRelative("TimeResyncInterval");
-        m_EnableNetworkVariableProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableNetworkVariable");
-        m_EnsureNetworkVariableLengthSafetyProperty = m_NetworkConfigProperty.FindPropertyRelative("EnsureNetworkVariableLengthSafety");
-        m_CreatePlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative("CreatePlayerPrefab");
-        m_ForceSamePrefabsProperty = m_NetworkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
-        m_EnableSceneManagementProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableSceneManagement");
-        m_RecycleNetworkIdsProperty = m_NetworkConfigProperty.FindPropertyRelative("RecycleNetworkIds");
-        m_NetworkIdRecycleDelayProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkIdRecycleDelay");
-        m_RpcHashSizeProperty = m_NetworkConfigProperty.FindPropertyRelative("RpcHashSize");
-        m_LoadSceneTimeOutProperty = m_NetworkConfigProperty.FindPropertyRelative("LoadSceneTimeOut");
-        m_EnableMessageBufferingProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableMessageBuffering");
-        m_MessageBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("MessageBufferTimeout");
-    }
-
-    private void OnEnable()
-    {
-        m_NetworkPrefabsList = new ReorderableList(serializedObject, serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig)).FindPropertyRelative(nameof(NetworkConfig.NetworkPrefabs)), true, true, true, true);
-        m_NetworkPrefabsList.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) =>
-        {
-            for (int i = 0; i < m_NetworkManager.NetworkConfig.NetworkPrefabs.Count; i++)
+            if (m_Initialized)
             {
-                // Find the first playerPrefab
-                if (m_NetworkManager.NetworkConfig.NetworkPrefabs[i].IsPlayer)
+                return;
+            }
+
+            m_Initialized = true;
+            m_NetworkManager = (NetworkManager)target;
+
+            // Base properties
+            m_DontDestroyOnLoadProperty = serializedObject.FindProperty(nameof(NetworkManager.DontDestroy));
+            m_RunInBackgroundProperty = serializedObject.FindProperty(nameof(NetworkManager.RunInBackground));
+            m_LogLevelProperty = serializedObject.FindProperty(nameof(NetworkManager.LogLevel));
+            m_NetworkConfigProperty = serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig));
+
+            // NetworkConfig properties
+            m_PlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative(nameof(NetworkConfig.PlayerPrefab));
+            m_ProtocolVersionProperty = m_NetworkConfigProperty.FindPropertyRelative("ProtocolVersion");
+            m_AllowRuntimeSceneChangesProperty = m_NetworkConfigProperty.FindPropertyRelative("AllowRuntimeSceneChanges");
+            m_NetworkTransportProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTransport");
+            m_ReceiveTickrateProperty = m_NetworkConfigProperty.FindPropertyRelative("ReceiveTickrate");
+            m_NetworkTickIntervalSecProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTickIntervalSec");
+            m_MaxReceiveEventsPerTickRateProperty = m_NetworkConfigProperty.FindPropertyRelative("MaxReceiveEventsPerTickRate");
+            m_EventTickrateProperty = m_NetworkConfigProperty.FindPropertyRelative("EventTickrate");
+            m_ClientConnectionBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
+            m_ConnectionApprovalProperty = m_NetworkConfigProperty.FindPropertyRelative("ConnectionApproval");
+            m_EnableTimeResyncProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableTimeResync");
+            m_TimeResyncIntervalProperty = m_NetworkConfigProperty.FindPropertyRelative("TimeResyncInterval");
+            m_EnableNetworkVariableProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableNetworkVariable");
+            m_EnsureNetworkVariableLengthSafetyProperty = m_NetworkConfigProperty.FindPropertyRelative("EnsureNetworkVariableLengthSafety");
+            m_CreatePlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative("CreatePlayerPrefab");
+            m_ForceSamePrefabsProperty = m_NetworkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
+            m_UsePrefabSyncProperty = m_NetworkConfigProperty.FindPropertyRelative("UsePrefabSync");
+            m_EnableSceneManagementProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableSceneManagement");
+            m_RecycleNetworkIdsProperty = m_NetworkConfigProperty.FindPropertyRelative("RecycleNetworkIds");
+            m_NetworkIdRecycleDelayProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkIdRecycleDelay");
+            m_RpcHashSizeProperty = m_NetworkConfigProperty.FindPropertyRelative("RpcHashSize");
+            m_LoadSceneTimeOutProperty = m_NetworkConfigProperty.FindPropertyRelative("LoadSceneTimeOut");
+            m_EnableMessageBufferingProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableMessageBuffering");
+            m_MessageBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("MessageBufferTimeout");
+
+
+            ReloadTransports();
+        }
+
+        private void CheckNullProperties()
+        {
+            // Base properties
+            m_DontDestroyOnLoadProperty = serializedObject.FindProperty(nameof(NetworkManager.DontDestroy));
+            m_RunInBackgroundProperty = serializedObject.FindProperty(nameof(NetworkManager.RunInBackground));
+            m_LogLevelProperty = serializedObject.FindProperty(nameof(NetworkManager.LogLevel));
+            m_NetworkConfigProperty = serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig));
+
+            // NetworkConfig properties
+            m_PlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative(nameof(NetworkConfig.PlayerPrefab));
+            m_ProtocolVersionProperty = m_NetworkConfigProperty.FindPropertyRelative("ProtocolVersion");
+            m_AllowRuntimeSceneChangesProperty = m_NetworkConfigProperty.FindPropertyRelative("AllowRuntimeSceneChanges");
+            m_NetworkTransportProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTransport");
+            m_ReceiveTickrateProperty = m_NetworkConfigProperty.FindPropertyRelative("ReceiveTickrate");
+            m_NetworkTickIntervalSecProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTickIntervalSec");
+            m_MaxReceiveEventsPerTickRateProperty = m_NetworkConfigProperty.FindPropertyRelative("MaxReceiveEventsPerTickRate");
+            m_EventTickrateProperty = m_NetworkConfigProperty.FindPropertyRelative("EventTickrate");
+            m_ClientConnectionBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
+            m_ConnectionApprovalProperty = m_NetworkConfigProperty.FindPropertyRelative("ConnectionApproval");
+            m_EnableTimeResyncProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableTimeResync");
+            m_TimeResyncIntervalProperty = m_NetworkConfigProperty.FindPropertyRelative("TimeResyncInterval");
+            m_EnableNetworkVariableProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableNetworkVariable");
+            m_EnsureNetworkVariableLengthSafetyProperty = m_NetworkConfigProperty.FindPropertyRelative("EnsureNetworkVariableLengthSafety");
+            m_CreatePlayerPrefabProperty = m_NetworkConfigProperty.FindPropertyRelative("CreatePlayerPrefab");
+            m_ForceSamePrefabsProperty = m_NetworkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
+            m_EnableSceneManagementProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableSceneManagement");
+            m_RecycleNetworkIdsProperty = m_NetworkConfigProperty.FindPropertyRelative("RecycleNetworkIds");
+            m_NetworkIdRecycleDelayProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkIdRecycleDelay");
+            m_RpcHashSizeProperty = m_NetworkConfigProperty.FindPropertyRelative("RpcHashSize");
+            m_LoadSceneTimeOutProperty = m_NetworkConfigProperty.FindPropertyRelative("LoadSceneTimeOut");
+            m_EnableMessageBufferingProperty = m_NetworkConfigProperty.FindPropertyRelative("EnableMessageBuffering");
+            m_MessageBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("MessageBufferTimeout");
+        }
+
+        private void OnEnable()
+        {
+            m_NetworkPrefabsList = new ReorderableList(serializedObject, serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig)).FindPropertyRelative(nameof(NetworkConfig.NetworkPrefabs)), true, true, true, true);
+            m_NetworkPrefabsList.elementHeightCallback = index =>
+            {
+                var networkPrefab = m_NetworkPrefabsList.serializedProperty.GetArrayElementAtIndex(index);
+                var networkOverrideProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.Override));
+                var networkOverrideInt = networkOverrideProp.enumValueIndex;
+
+                return 10 + (networkOverrideInt == 0 ? EditorGUIUtility.singleLineHeight : (EditorGUIUtility.singleLineHeight * 2) + 5);
+            };
+            m_NetworkPrefabsList.drawElementCallback = (rect, index, isActive, isFocused) =>
+            {
+                rect.y += 5;
+
+                var networkPrefab = m_NetworkPrefabsList.serializedProperty.GetArrayElementAtIndex(index);
+                var networkPrefabProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.Prefab));
+                var networkSourceHashProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.OverridingSourceHash));
+                var networkSourcePrefabProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.OverridingSourcePrefab));
+                var networkTargetPrefabProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.OverridingTargetPrefab));
+                var networkOverrideProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.Override));
+                var networkOverrideInt = networkOverrideProp.enumValueIndex;
+                var networkOverrideEnum = (NetworkPrefabOverride)networkOverrideInt;
+                EditorGUI.LabelField(new Rect(rect.x + rect.width - 70, rect.y, 60, EditorGUIUtility.singleLineHeight), "Override");
+                if (networkOverrideEnum == NetworkPrefabOverride.Unset)
                 {
-                    // Iterate over all other and set player prefab to false
-                    for (int j = 0; j < m_NetworkManager.NetworkConfig.NetworkPrefabs.Count; j++)
+                    if (EditorGUI.Toggle(new Rect(rect.x + rect.width - 15, rect.y, 10, EditorGUIUtility.singleLineHeight), false))
                     {
-                        if (j != i && m_NetworkManager.NetworkConfig.NetworkPrefabs[j].IsPlayer)
-                        {
-                            m_NetworkManager.NetworkConfig.NetworkPrefabs[j].IsPlayer = false;
-                        }
+                        networkOverrideProp.enumValueIndex = (int)NetworkPrefabOverride.Prefab;
+                    }
+                }
+                else
+                {
+                    if (!EditorGUI.Toggle(new Rect(rect.x + rect.width - 15, rect.y, 10, EditorGUIUtility.singleLineHeight), true))
+                    {
+                        networkOverrideProp.enumValueIndex = 0;
+                        networkOverrideEnum = NetworkPrefabOverride.Unset;
+                    }
+                }
+
+                if (networkOverrideEnum == NetworkPrefabOverride.Unset)
+                {
+                    EditorGUI.PropertyField(new Rect(rect.x, rect.y, rect.width - 80, EditorGUIUtility.singleLineHeight), networkPrefabProp, GUIContent.none);
+                }
+                else
+                {
+                    networkOverrideProp.enumValueIndex = GUI.Toolbar(new Rect(rect.x, rect.y, 100, EditorGUIUtility.singleLineHeight), networkOverrideInt - 1, new[] { "Prefab", "Hash" }) + 1;
+
+                    if (networkOverrideEnum == NetworkPrefabOverride.Prefab)
+                    {
+                        EditorGUI.PropertyField(new Rect(rect.x + 110, rect.y, rect.width - 190, EditorGUIUtility.singleLineHeight), networkSourcePrefabProp, GUIContent.none);
+                    }
+                    else
+                    {
+                        EditorGUI.PropertyField(new Rect(rect.x + 110, rect.y, rect.width - 190, EditorGUIUtility.singleLineHeight), networkSourceHashProp, GUIContent.none);
                     }
 
-                    break;
+                    rect.y += EditorGUIUtility.singleLineHeight + 5;
+
+                    EditorGUI.LabelField(new Rect(rect.x, rect.y, 100, EditorGUIUtility.singleLineHeight), "Overriding Prefab");
+                    EditorGUI.PropertyField(new Rect(rect.x + 110, rect.y, rect.width - 110, EditorGUIUtility.singleLineHeight), networkTargetPrefabProp, GUIContent.none);
                 }
-            }
+            };
+            m_NetworkPrefabsList.drawHeaderCallback = rect => EditorGUI.LabelField(rect, "NetworkPrefabs");
 
-            var element = m_NetworkPrefabsList.serializedProperty.GetArrayElementAtIndex(index);
-            int firstLabelWidth = 50;
-            int secondLabelWidth = 140;
-            float secondFieldWidth = 10;
-            int reduceFirstWidth = 45;
-
-            EditorGUI.LabelField(new Rect(rect.x, rect.y, firstLabelWidth, EditorGUIUtility.singleLineHeight), "Prefab");
-            EditorGUI.PropertyField(new Rect(rect.x + firstLabelWidth, rect.y, rect.width - firstLabelWidth - secondLabelWidth - secondFieldWidth - reduceFirstWidth,
-                EditorGUIUtility.singleLineHeight), element.FindPropertyRelative(nameof(NetworkPrefab.Prefab)), GUIContent.none);
-
-            EditorGUI.LabelField(new Rect(rect.width - secondLabelWidth - secondFieldWidth, rect.y, secondLabelWidth, EditorGUIUtility.singleLineHeight), "Default Player Prefab");
-
-            int playerPrefabIndex = -1;
-
-            for (int i = 0; i < m_NetworkManager.NetworkConfig.NetworkPrefabs.Count; i++)
+            m_RegisteredScenesList = new ReorderableList(serializedObject, serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig)).FindPropertyRelative(nameof(NetworkConfig.RegisteredScenes)), true, true, true, true);
+            m_RegisteredScenesList.drawElementCallback = (rect, index, isActive, isFocused) =>
             {
-                if (m_NetworkManager.NetworkConfig.NetworkPrefabs[i].IsPlayer)
-                {
-                    playerPrefabIndex = i;
-                    break;
-                }
-            }
+                var element = m_RegisteredScenesList.serializedProperty.GetArrayElementAtIndex(index);
+                int firstLabelWidth = 50;
+                int padding = 20;
 
-            using (new EditorGUI.DisabledScope(playerPrefabIndex != -1 && playerPrefabIndex != index))
-            {
-                EditorGUI.PropertyField(new Rect(rect.width - secondFieldWidth, rect.y, secondFieldWidth,
-                    EditorGUIUtility.singleLineHeight), element.FindPropertyRelative(nameof(NetworkPrefab.IsPlayer)), GUIContent.none);
-            }
-        };
-
-        m_NetworkPrefabsList.drawHeaderCallback = (Rect rect) => { EditorGUI.LabelField(rect, "NetworkPrefabs"); };
-
-
-        m_RegisteredScenesList = new ReorderableList(serializedObject, serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig)).FindPropertyRelative(nameof(NetworkConfig.RegisteredScenes)), true, true, true, true);
-        m_RegisteredScenesList.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) =>
-        {
-            var element = m_RegisteredScenesList.serializedProperty.GetArrayElementAtIndex(index);
-            int firstLabelWidth = 50;
-            int padding = 20;
-
-            EditorGUI.LabelField(new Rect(rect.x, rect.y, firstLabelWidth, EditorGUIUtility.singleLineHeight), "Name");
-            EditorGUI.PropertyField(new Rect(rect.x + firstLabelWidth, rect.y, rect.width - firstLabelWidth - padding,
-                EditorGUIUtility.singleLineHeight), element, GUIContent.none);
-        };
-
-        m_RegisteredScenesList.drawHeaderCallback = (Rect rect) => { EditorGUI.LabelField(rect, "Registered Scene Names"); };
-    }
-
-    public override void OnInspectorGUI()
-    {
-        Init();
-        CheckNullProperties();
-
-        {
-            var iterator = serializedObject.GetIterator();
-
-            for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
-            {
-                using (new EditorGUI.DisabledScope("m_Script" == iterator.propertyPath))
-                {
-                    EditorGUILayout.PropertyField(iterator, false);
-                }
-            }
+                EditorGUI.LabelField(new Rect(rect.x, rect.y, firstLabelWidth, EditorGUIUtility.singleLineHeight), "Name");
+                EditorGUI.PropertyField(new Rect(rect.x + firstLabelWidth, rect.y, rect.width - firstLabelWidth - padding, EditorGUIUtility.singleLineHeight), element, GUIContent.none);
+            };
+            m_RegisteredScenesList.drawHeaderCallback = rect => EditorGUI.LabelField(rect, "Registered Scene Names");
         }
 
-
-        if (!m_NetworkManager.IsServer && !m_NetworkManager.IsClient)
+        public override void OnInspectorGUI()
         {
-            serializedObject.Update();
-            EditorGUILayout.PropertyField(m_DontDestroyOnLoadProperty);
-            EditorGUILayout.PropertyField(m_RunInBackgroundProperty);
-            EditorGUILayout.PropertyField(m_LogLevelProperty);
+            Initialize();
+            CheckNullProperties();
 
-            EditorGUILayout.Space();
-            m_NetworkPrefabsList.DoLayoutList();
-
-            using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableSceneManagement))
             {
-                m_RegisteredScenesList.DoLayoutList();
+                var iterator = serializedObject.GetIterator();
+
+                for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
+                {
+                    using (new EditorGUI.DisabledScope("m_Script" == iterator.propertyPath))
+                    {
+                        EditorGUILayout.PropertyField(iterator, false);
+                    }
+                }
+            }
+
+
+            if (!m_NetworkManager.IsServer && !m_NetworkManager.IsClient)
+            {
+                serializedObject.Update();
+                EditorGUILayout.PropertyField(m_DontDestroyOnLoadProperty);
+                EditorGUILayout.PropertyField(m_RunInBackgroundProperty);
+                EditorGUILayout.PropertyField(m_LogLevelProperty);
                 EditorGUILayout.Space();
-            }
 
+                EditorGUILayout.PropertyField(m_PlayerPrefabProperty);
+                EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField("General", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(m_ProtocolVersionProperty);
+                m_NetworkPrefabsList.DoLayoutList();
+                EditorGUILayout.Space();
 
-            EditorGUILayout.PropertyField(m_NetworkTransportProperty);
-
-            if (m_NetworkTransportProperty.objectReferenceValue == null)
-            {
-                EditorGUILayout.HelpBox("You have no transport selected. A transport is required for the MLAPI to work. Which one do you want?", MessageType.Warning);
-
-                int selection = EditorGUILayout.Popup(0, m_TransportNames);
-
-                if (selection > 0)
+                using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableSceneManagement))
                 {
-                    ReloadTransports();
+                    m_RegisteredScenesList.DoLayoutList();
+                    EditorGUILayout.Space();
+                }
 
-                    var transportComponent = m_NetworkManager.gameObject.GetComponent(m_TransportTypes[selection - 1]);
 
-                    if (transportComponent == null)
+                EditorGUILayout.LabelField("General", EditorStyles.boldLabel);
+                EditorGUILayout.PropertyField(m_ProtocolVersionProperty);
+
+                EditorGUILayout.PropertyField(m_NetworkTransportProperty);
+
+                if (m_NetworkTransportProperty.objectReferenceValue == null)
+                {
+                    EditorGUILayout.HelpBox("You have no transport selected. A transport is required for the MLAPI to work. Which one do you want?", MessageType.Warning);
+
+                    int selection = EditorGUILayout.Popup(0, m_TransportNames);
+
+                    if (selection > 0)
                     {
-                        transportComponent = m_NetworkManager.gameObject.AddComponent(m_TransportTypes[selection - 1]);
+                        ReloadTransports();
+
+                        var transportComponent = m_NetworkManager.gameObject.GetComponent(m_TransportTypes[selection - 1]);
+
+                        if (transportComponent == null)
+                        {
+                            transportComponent = m_NetworkManager.gameObject.AddComponent(m_TransportTypes[selection - 1]);
+                        }
+
+                        m_NetworkTransportProperty.objectReferenceValue = transportComponent;
+
+                        Repaint();
+                    }
+                }
+
+                EditorGUILayout.PropertyField(m_EnableTimeResyncProperty);
+
+                using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableTimeResync))
+                {
+                    EditorGUILayout.PropertyField(m_TimeResyncIntervalProperty);
+                }
+
+                EditorGUILayout.LabelField("Performance", EditorStyles.boldLabel);
+                EditorGUILayout.PropertyField(m_ReceiveTickrateProperty);
+                EditorGUILayout.PropertyField(m_NetworkTickIntervalSecProperty);
+                EditorGUILayout.PropertyField(m_MaxReceiveEventsPerTickRateProperty);
+                EditorGUILayout.PropertyField(m_EventTickrateProperty);
+                EditorGUILayout.PropertyField(m_EnableNetworkVariableProperty);
+
+                using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableNetworkVariable))
+                {
+                    if (m_MaxObjectUpdatesPerTickProperty != null)
+                    {
+                        EditorGUILayout.PropertyField(m_MaxObjectUpdatesPerTickProperty);
                     }
 
-                    m_NetworkTransportProperty.objectReferenceValue = transportComponent;
-
-                    Repaint();
+                    EditorGUILayout.PropertyField(m_EnsureNetworkVariableLengthSafetyProperty);
                 }
-            }
 
-            EditorGUILayout.PropertyField(m_EnableTimeResyncProperty);
+                EditorGUILayout.LabelField("Connection", EditorStyles.boldLabel);
+                EditorGUILayout.PropertyField(m_ConnectionApprovalProperty);
 
-            using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableTimeResync))
-            {
-                EditorGUILayout.PropertyField(m_TimeResyncIntervalProperty);
-            }
-
-            EditorGUILayout.LabelField("Performance", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(m_ReceiveTickrateProperty);
-            EditorGUILayout.PropertyField(m_NetworkTickIntervalSecProperty);
-            EditorGUILayout.PropertyField(m_MaxReceiveEventsPerTickRateProperty);
-            EditorGUILayout.PropertyField(m_EventTickrateProperty);
-            EditorGUILayout.PropertyField(m_EnableNetworkVariableProperty);
-
-            using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableNetworkVariable))
-            {
-                if (m_MaxObjectUpdatesPerTickProperty != null)
+                using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.ConnectionApproval))
                 {
-                    EditorGUILayout.PropertyField(m_MaxObjectUpdatesPerTickProperty);
+                    EditorGUILayout.PropertyField(m_ClientConnectionBufferTimeoutProperty);
                 }
 
-                EditorGUILayout.PropertyField(m_EnsureNetworkVariableLengthSafetyProperty);
-            }
-
-            EditorGUILayout.LabelField("Connection", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(m_ConnectionApprovalProperty);
-
-            using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.ConnectionApproval))
-            {
-                EditorGUILayout.PropertyField(m_ClientConnectionBufferTimeoutProperty);
-            }
-
-            EditorGUILayout.LabelField("Spawning", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(m_CreatePlayerPrefabProperty);
-            EditorGUILayout.PropertyField(m_ForceSamePrefabsProperty);
-
-            EditorGUILayout.PropertyField(m_RecycleNetworkIdsProperty);
-
-            using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.RecycleNetworkIds))
-            {
-                EditorGUILayout.PropertyField(m_NetworkIdRecycleDelayProperty);
-            }
-
-            EditorGUILayout.PropertyField(m_EnableMessageBufferingProperty);
-
-            using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableMessageBuffering))
-            {
-                EditorGUILayout.PropertyField(m_MessageBufferTimeoutProperty);
-            }
-
-            EditorGUILayout.LabelField("Bandwidth", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(m_RpcHashSizeProperty);
-
-            EditorGUILayout.LabelField("Scene Management", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(m_EnableSceneManagementProperty);
-
-            using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableSceneManagement))
-            {
-                EditorGUILayout.PropertyField(m_LoadSceneTimeOutProperty);
-                EditorGUILayout.PropertyField(m_AllowRuntimeSceneChangesProperty);
-            }
-
-            serializedObject.ApplyModifiedProperties();
+                EditorGUILayout.LabelField("Spawning", EditorStyles.boldLabel);
+                EditorGUILayout.PropertyField(m_CreatePlayerPrefabProperty);
+                EditorGUILayout.PropertyField(m_ForceSamePrefabsProperty);
 
 
-            // Start buttons below
-            {
-                string buttonDisabledReasonSuffix = "";
+                EditorGUILayout.PropertyField(m_RecycleNetworkIdsProperty);
 
-                if (!EditorApplication.isPlaying)
+                using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.RecycleNetworkIds))
                 {
-                    buttonDisabledReasonSuffix = ". This can only be done in play mode";
-                    GUI.enabled = false;
+                    EditorGUILayout.PropertyField(m_NetworkIdRecycleDelayProperty);
                 }
 
-                if (GUILayout.Button(new GUIContent("Start Host", "Starts a host instance" + buttonDisabledReasonSuffix)))
+                EditorGUILayout.PropertyField(m_EnableMessageBufferingProperty);
+
+                using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableMessageBuffering))
                 {
-                    m_NetworkManager.StartHost();
+                    EditorGUILayout.PropertyField(m_MessageBufferTimeoutProperty);
                 }
 
-                if (GUILayout.Button(new GUIContent("Start Server", "Starts a server instance" + buttonDisabledReasonSuffix)))
+                EditorGUILayout.LabelField("Bandwidth", EditorStyles.boldLabel);
+                EditorGUILayout.PropertyField(m_RpcHashSizeProperty);
+
+                EditorGUILayout.LabelField("Scene Management", EditorStyles.boldLabel);
+                EditorGUILayout.PropertyField(m_EnableSceneManagementProperty);
+
+                using (new EditorGUI.DisabledScope(!m_NetworkManager.NetworkConfig.EnableSceneManagement))
                 {
-                    m_NetworkManager.StartServer();
+                    EditorGUILayout.PropertyField(m_LoadSceneTimeOutProperty);
+                    EditorGUILayout.PropertyField(m_AllowRuntimeSceneChangesProperty);
                 }
 
-                if (GUILayout.Button(new GUIContent("Start Client", "Starts a client instance" + buttonDisabledReasonSuffix)))
-                {
-                    m_NetworkManager.StartClient();
-                }
+                serializedObject.ApplyModifiedProperties();
 
-                if (!EditorApplication.isPlaying)
+
+                // Start buttons below
                 {
-                    GUI.enabled = true;
+                    string buttonDisabledReasonSuffix = "";
+
+                    if (!EditorApplication.isPlaying)
+                    {
+                        buttonDisabledReasonSuffix = ". This can only be done in play mode";
+                        GUI.enabled = false;
+                    }
+
+                    if (GUILayout.Button(new GUIContent("Start Host", "Starts a host instance" + buttonDisabledReasonSuffix)))
+                    {
+                        m_NetworkManager.StartHost();
+                    }
+
+                    if (GUILayout.Button(new GUIContent("Start Server", "Starts a server instance" + buttonDisabledReasonSuffix)))
+                    {
+                        m_NetworkManager.StartServer();
+                    }
+
+                    if (GUILayout.Button(new GUIContent("Start Client", "Starts a client instance" + buttonDisabledReasonSuffix)))
+                    {
+                        m_NetworkManager.StartClient();
+                    }
+
+                    if (!EditorApplication.isPlaying)
+                    {
+                        GUI.enabled = true;
+                    }
                 }
             }
-        }
-        else
-        {
-            string instanceType = string.Empty;
+            else
+            {
+                string instanceType = string.Empty;
 
-            if (m_NetworkManager.IsHost)
-            {
-                instanceType = "Host";
-            }
-            else if (m_NetworkManager.IsServer)
-            {
-                instanceType = "Server";
-            }
-            else if (m_NetworkManager.IsClient)
-            {
-                instanceType = "Client";
-            }
-
-            EditorGUILayout.HelpBox("You cannot edit the NetworkConfig when a " + instanceType + " is running.", MessageType.Info);
-
-            if (GUILayout.Button(new GUIContent("Stop " + instanceType, "Stops the " + instanceType + " instance.")))
-            {
                 if (m_NetworkManager.IsHost)
                 {
-                    m_NetworkManager.StopHost();
+                    instanceType = "Host";
                 }
                 else if (m_NetworkManager.IsServer)
                 {
-                    m_NetworkManager.StopServer();
+                    instanceType = "Server";
                 }
                 else if (m_NetworkManager.IsClient)
                 {
-                    m_NetworkManager.StopClient();
+                    instanceType = "Client";
+                }
+
+                EditorGUILayout.HelpBox("You cannot edit the NetworkConfig when a " + instanceType + " is running.", MessageType.Info);
+
+                if (GUILayout.Button(new GUIContent("Stop " + instanceType, "Stops the " + instanceType + " instance.")))
+                {
+                    if (m_NetworkManager.IsHost)
+                    {
+                        m_NetworkManager.StopHost();
+                    }
+                    else if (m_NetworkManager.IsServer)
+                    {
+                        m_NetworkManager.StopServer();
+                    }
+                    else if (m_NetworkManager.IsClient)
+                    {
+                        m_NetworkManager.StopClient();
+                    }
                 }
             }
         }

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -41,12 +41,25 @@ namespace MLAPI.Configuration
                  "If this is true, clients with different initial configurations will not work together.")]
         public bool AllowRuntimeSceneChanges = false;
 
-#if UNITY_EDITOR
         /// <summary>
-        /// The default player prefab
+        /// The previously set default player prefab
+        /// Note: this is only for an editor specific scenario where we need to determine during the
+        /// NetworkManager.OnValidate invocation period there is no PlayerPrefab value yet there is a
+        /// NetworkPrefab entry that has IsPlayer set to true.  This is also used to determine if
+        /// we are loading from a previous MLAPI version where the NetworkPrefab.IsPlayer was predominantly
+        /// used.
+        /// There are two scenarios where this is used:
+        /// 1.) If the PreviousPlayerPrefab and PlayerPrefab values are not set but a NetworkPrefab has
+        /// an entry with the NetworkPrefab.IsPlayer set to true, then we want to assign the PlayerPrefab
+        /// and PreviousPlayerPrefab
+        /// 2.) If the PlayerPrefab is null, the PreviousPlayer prefab is not, a NetworkPrefab entry
+        /// has its NetworkPrefab.IsPlayer set to true, and that NetworkPrefab entry's prefab's
+        /// NetworkObject.GlobalObjectIdHash is the same as the PreviousPlayerPrefab's NetworkObject.GlobalObjectIdHash
+        /// then the user deleted the PlayerPrefab so we can mark the NetworkPrefab.IsPlayer value of the matching
+        /// NetworkPrefab to false and the PreviousPlayerPrefab to null.
+        /// (The next time PlayerPrefab is set see scenario #1)
         /// </summary>
-        public GameObject PreviousPlayerPrefab;
-#endif
+        internal GameObject PreviousPlayerPrefab;
 
         /// <summary>
         /// The default player prefab

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -42,16 +42,18 @@ namespace MLAPI.Configuration
         public bool AllowRuntimeSceneChanges = false;
 
         /// <summary>
+        /// The default player prefab
+        /// </summary>
+        public GameObject PlayerPrefab;
+
+        /// <summary>
         /// A list of spawnable prefabs
         /// </summary>
         [Tooltip("The prefabs that can be spawned across the network")]
         public List<NetworkPrefab> NetworkPrefabs = new List<NetworkPrefab>();
 
-        /// <summary>
-        /// The default player prefab
-        /// </summary>
-        [SerializeReference]
-        internal uint PlayerPrefabHash;
+
+        public Dictionary<uint, NetworkPrefab> HashedNetworkPrefabs = new Dictionary<uint, NetworkPrefab>();
 
         /// <summary>
         /// Whether or not a player object should be created by default. This value can be overridden on a case by case basis with ConnectionApproval.

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -301,10 +301,10 @@ namespace MLAPI.Configuration
 
                 if (ForceSamePrefabs)
                 {
-                    var sortedPrefabList = NetworkPrefabs.OrderBy(x => x.Hash).ToList();
-                    for (int i = 0; i < sortedPrefabList.Count; i++)
+                    var sortedDictionary = NetworkPrefabOverrideLinks.OrderBy(x => x.Key);
+                    foreach (var sortedEntry in sortedDictionary)
                     {
-                        writer.WriteUInt32Packed(sortedPrefabList[i].Hash);
+                        writer.WriteUInt32Packed(sortedEntry.Key);
                     }
                 }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -50,8 +50,9 @@ namespace MLAPI.Configuration
         /// <summary>
         /// A list of spawnable prefabs
         /// </summary>
+        [SerializeField]
         [Tooltip("The prefabs that can be spawned across the network")]
-        public List<NetworkPrefab> NetworkPrefabs = new List<NetworkPrefab>();
+        internal List<NetworkPrefab> NetworkPrefabs = new List<NetworkPrefab>();
 
         /// <summary>
         /// This dictionary provides a quick way to check and see if a NetworkPrefab has a NetworkPrefab override.

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -72,14 +72,11 @@ namespace MLAPI.Configuration
         [Tooltip("The prefabs that can be spawned across the network")]
         public List<NetworkPrefab> NetworkPrefabs = new List<NetworkPrefab>();
 
-
-        public Dictionary<uint, NetworkPrefab>NetworkPrefabOverrideLinks = new Dictionary<uint, NetworkPrefab>();
-
         /// <summary>
-        /// Whether or not a player object should be created by default. This value can be overridden on a case by case basis with ConnectionApproval.
+        /// This dictionary provides a quick way to check and see if a NetworkPrefab has a NetworkPrefab override.
+        /// Generated at runtime and OnValidate
         /// </summary>
-        [Tooltip("Whether or not a player object should be created by default. This value can be overridden on a case by case basis with ConnectionApproval.")]
-        public bool CreatePlayerPrefab = true;
+        public Dictionary<uint, NetworkPrefab>NetworkPrefabOverrideLinks = new Dictionary<uint, NetworkPrefab>();
 
         /// <summary>
         /// Amount of times per second the receive queue is emptied and all messages inside are processed.

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -53,7 +53,7 @@ namespace MLAPI.Configuration
         public List<NetworkPrefab> NetworkPrefabs = new List<NetworkPrefab>();
 
 
-        public Dictionary<uint, NetworkPrefab> HashedNetworkPrefabs = new Dictionary<uint, NetworkPrefab>();
+        public Dictionary<uint, NetworkPrefab>NetworkPrefabOverrideLinks = new Dictionary<uint, NetworkPrefab>();
 
         /// <summary>
         /// Whether or not a player object should be created by default. This value can be overridden on a case by case basis with ConnectionApproval.

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -42,29 +42,9 @@ namespace MLAPI.Configuration
         public bool AllowRuntimeSceneChanges = false;
 
         /// <summary>
-        /// The previously set default player prefab
-        /// Note: this is only for an editor specific scenario where we need to determine during the
-        /// NetworkManager.OnValidate invocation period there is no PlayerPrefab value yet there is a
-        /// NetworkPrefab entry that has IsPlayer set to true.  This is also used to determine if
-        /// we are loading from a previous MLAPI version where the NetworkPrefab.IsPlayer was predominantly
-        /// used.
-        /// There are two scenarios where this is used:
-        /// 1.) If the PreviousPlayerPrefab and PlayerPrefab values are not set but a NetworkPrefab has
-        /// an entry with the NetworkPrefab.IsPlayer set to true, then we want to assign the PlayerPrefab
-        /// and PreviousPlayerPrefab
-        /// 2.) If the PlayerPrefab is null, the PreviousPlayer prefab is not, a NetworkPrefab entry
-        /// has its NetworkPrefab.IsPlayer set to true, and that NetworkPrefab entry's prefab's
-        /// NetworkObject.GlobalObjectIdHash is the same as the PreviousPlayerPrefab's NetworkObject.GlobalObjectIdHash
-        /// then the user deleted the PlayerPrefab so we can mark the NetworkPrefab.IsPlayer value of the matching
-        /// NetworkPrefab to false and the PreviousPlayerPrefab to null.
-        /// (The next time PlayerPrefab is set see scenario #1)
-        /// </summary>
-        internal GameObject PreviousPlayerPrefab;
-
-        /// <summary>
         /// The default player prefab
         /// </summary>
-        [Tooltip("When set, the network manager will automatically create and spawn the assigned player prefab.  The Player Prefab can be overriden by adding it to the NetworkPrefabs list and selecting override.")]
+        [Tooltip("When set, NetworkManager will automatically create and spawn the assigned player prefab. This can be overridden by adding it to the NetworkPrefabs list and selecting override.")]
         public GameObject PlayerPrefab;
 
         /// <summary>
@@ -77,7 +57,7 @@ namespace MLAPI.Configuration
         /// This dictionary provides a quick way to check and see if a NetworkPrefab has a NetworkPrefab override.
         /// Generated at runtime and OnValidate
         /// </summary>
-        public Dictionary<uint, NetworkPrefab>NetworkPrefabOverrideLinks = new Dictionary<uint, NetworkPrefab>();
+        internal Dictionary<uint, NetworkPrefab> NetworkPrefabOverrideLinks = new Dictionary<uint, NetworkPrefab>();
 
         /// <summary>
         /// Amount of times per second the receive queue is emptied and all messages inside are processed.

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -41,6 +41,13 @@ namespace MLAPI.Configuration
                  "If this is true, clients with different initial configurations will not work together.")]
         public bool AllowRuntimeSceneChanges = false;
 
+#if UNITY_EDITOR
+        /// <summary>
+        /// The default player prefab
+        /// </summary>
+        public GameObject PreviousPlayerPrefab;
+#endif
+
         /// <summary>
         /// The default player prefab
         /// </summary>

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConfig.cs
@@ -64,6 +64,7 @@ namespace MLAPI.Configuration
         /// <summary>
         /// The default player prefab
         /// </summary>
+        [Tooltip("When set, the network manager will automatically create and spawn the assigned player prefab.  The Player Prefab can be overriden by adding it to the NetworkPrefabs list and selecting override.")]
         public GameObject PlayerPrefab;
 
         /// <summary>

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace MLAPI.Configuration
 {
-    public enum NetworkPrefabOverride
+    internal enum NetworkPrefabOverride
     {
         None,
         Prefab,
@@ -15,7 +15,7 @@ namespace MLAPI.Configuration
     /// Class that represents a NetworkPrefab
     /// </summary>
     [Serializable]
-    public class NetworkPrefab
+    internal class NetworkPrefab
     {
         /// <summary>
         /// The override setttings for this NetworkPrefab
@@ -53,7 +53,6 @@ namespace MLAPI.Configuration
                     {
                         NetworkLog.LogWarning($"{nameof(NetworkPrefab)} does not have a prefab assigned");
                     }
-
                     return 0;
                 }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
@@ -27,14 +27,14 @@ namespace MLAPI.Configuration
         /// <summary>
         /// The original "source" prefab
         /// </summary>
-        public GameObject OverridingSourcePrefab;
+        public GameObject SourcePrefabToOverride;
 
         /// <summary>
         /// The original "source" prefab's hash
         /// This is used typically in multi-project patterns where a separate project contains the
         /// source prefab and the GlobalObjectIdHash was copied and pasted into this field.
         /// </summary>
-        public uint OverridingSourceHash;
+        public uint SourceHashToOverride;
 
         /// <summary>
         /// The prefab to replace the OverridingSourcePrefab with

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
@@ -6,7 +6,7 @@ namespace MLAPI.Configuration
 {
     public enum NetworkPrefabOverride
     {
-        Unset,
+        None,
         Prefab,
         Hash
     }

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
@@ -42,48 +42,5 @@ namespace MLAPI.Configuration
         /// The prefab to replace (override) the source prefab with
         /// </summary>
         public GameObject OverridingTargetPrefab;
-
-        internal uint Hash
-        {
-            get
-            {
-                if (Prefab == null)
-                {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                    {
-                        NetworkLog.LogWarning($"{nameof(NetworkPrefab)} does not have a prefab assigned");
-                    }
-                    return 0;
-                }
-
-                var prefabGameObject = Prefab;
-                
-                switch(Override)
-                {
-                    case NetworkPrefabOverride.Prefab:
-                        {
-                            prefabGameObject = SourcePrefabToOverride;
-                            break;
-                        }
-                    case NetworkPrefabOverride.Hash:
-                        {
-                            return SourceHashToOverride;
-                        }
-                }
-
-                var networkObject = prefabGameObject.GetComponent<NetworkObject>();
-                if (networkObject == null)
-                {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                    {
-                        NetworkLog.LogWarning($"{nameof(NetworkPrefab)} {prefabGameObject.name} does not have a {nameof(NetworkObject)} component");
-                    }
-
-                    return 0;
-                }
-
-                return networkObject.GlobalObjectIdHash;
-            }
-        }
     }
 }

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
@@ -25,19 +25,17 @@ namespace MLAPI.Configuration
         public NetworkPrefabOverride Override;
 
         /// <summary>
-        /// The original "source" prefab
+        /// Used when prefab is selected for the source prefab to override value (i.e. direct reference, the prefab is within the same project)
         /// </summary>
         public GameObject SourcePrefabToOverride;
 
         /// <summary>
-        /// The original "source" prefab's hash
-        /// This is used typically in multi-project patterns where a separate project contains the
-        /// source prefab and the GlobalObjectIdHash was copied and pasted into this field.
+        /// Used when hash is selected for the source prefab to override value (i.e. a direct reference is not possible such as in a multi-project pattern)
         /// </summary>
         public uint SourceHashToOverride;
 
         /// <summary>
-        /// The prefab to replace the OverridingSourcePrefab with
+        /// The prefab to replace (override) the source prefab with
         /// </summary>
         public GameObject OverridingTargetPrefab;
 

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
@@ -4,6 +4,13 @@ using UnityEngine;
 
 namespace MLAPI.Configuration
 {
+    public enum NetworkPrefabOverride
+    {
+        Unset,
+        Prefab,
+        Hash
+    }
+
     /// <summary>
     /// Class that represents a NetworkPrefab
     /// </summary>
@@ -14,6 +21,25 @@ namespace MLAPI.Configuration
         /// Asset reference of the network prefab
         /// </summary>
         public GameObject Prefab;
+
+        public NetworkPrefabOverride Override;
+
+        /// <summary>
+        /// The original "source" prefab
+        /// </summary>
+        public GameObject OverridingSourcePrefab;
+
+        /// <summary>
+        /// The original "source" prefab's hash
+        /// This is used typically in multi-project patterns where a separate project contains the
+        /// source prefab and the GlobalObjectIdHash was copied and pasted into this field.
+        /// </summary>
+        public uint OverridingSourceHash;
+
+        /// <summary>
+        /// The prefab to replace the OverridingSourcePrefab with
+        /// </summary>
+        public GameObject OverridingTargetPrefab;
 
         /// <summary>
         /// Whether or not this is a player prefab

--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkPrefab.cs
@@ -18,14 +18,18 @@ namespace MLAPI.Configuration
     public class NetworkPrefab
     {
         /// <summary>
+        /// The override setttings for this NetworkPrefab
+        /// </summary>
+        public NetworkPrefabOverride Override;
+
+        /// <summary>
         /// Asset reference of the network prefab
         /// </summary>
         public GameObject Prefab;
 
-        public NetworkPrefabOverride Override;
-
         /// <summary>
         /// Used when prefab is selected for the source prefab to override value (i.e. direct reference, the prefab is within the same project)
+        /// We keep a separate value as the user might want to have something different than the default Prefab for the SourcePrefabToOverride
         /// </summary>
         public GameObject SourcePrefabToOverride;
 
@@ -38,11 +42,6 @@ namespace MLAPI.Configuration
         /// The prefab to replace (override) the source prefab with
         /// </summary>
         public GameObject OverridingTargetPrefab;
-
-        /// <summary>
-        /// Whether or not this is a player prefab
-        /// </summary>
-        public bool IsPlayer;
 
         internal uint Hash
         {
@@ -58,12 +57,27 @@ namespace MLAPI.Configuration
                     return 0;
                 }
 
-                var networkObject = Prefab.GetComponent<NetworkObject>();
+                var prefabGameObject = Prefab;
+                
+                switch(Override)
+                {
+                    case NetworkPrefabOverride.Prefab:
+                        {
+                            prefabGameObject = SourcePrefabToOverride;
+                            break;
+                        }
+                    case NetworkPrefabOverride.Hash:
+                        {
+                            return SourceHashToOverride;
+                        }
+                }
+
+                var networkObject = prefabGameObject.GetComponent<NetworkObject>();
                 if (networkObject == null)
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                     {
-                        NetworkLog.LogWarning($"{nameof(NetworkPrefab)} {Prefab.name} does not have a {nameof(NetworkObject)} component");
+                        NetworkLog.LogWarning($"{nameof(NetworkPrefab)} {prefabGameObject.name} does not have a {nameof(NetworkObject)} component");
                     }
 
                     return 0;

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -216,7 +216,7 @@ namespace MLAPI
         {
             if (NetworkConfig == null)
             {
-                return; //May occur when the component is added
+                return; // May occur when the component is added
             }
 
             if (GetComponentInChildren<NetworkObject>() != null)
@@ -247,16 +247,16 @@ namespace MLAPI
                 };
             }
 
-            //If true, check to see if there is a defined player prefab in the Network prefab list
-            //This helps migrate v0.1.0 projects (i.e. no PlayerPrefab was assigned) as well as helps detect
-            //specific interface related issues related to the NetworkPrefabs list.
+            // If true, check to see if there is a defined player prefab in the Network prefab list
+            // This helps migrate v0.1.0 projects (i.e. no PlayerPrefab was assigned) as well as helps detect
+            // specific interface related issues related to the NetworkPrefabs list.
             var scanForPlayerPrefab = NetworkConfig.PlayerPrefab == null;
 
-            //During OnValidate we will always clear out NetworkPrefabOverrideLinks and rebuild it in order to
-            //detect specific edge case scenarios (See NtworkConfig.PreviousPlayerPrefab comments)
+            // During OnValidate we will always clear out NetworkPrefabOverrideLinks and rebuild it in order to
+            // detect specific edge case scenarios (See NtworkConfig.PreviousPlayerPrefab comments)
             NetworkConfig.NetworkPrefabOverrideLinks.Clear();
 
-            //Check network prefabs and assign to dictionary for quick look up
+            // Check network prefabs and assign to dictionary for quick look up
             for (int i = 0; i < NetworkConfig.NetworkPrefabs.Count; i++)
             {
                 if (NetworkConfig.NetworkPrefabs[i] != null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
@@ -271,15 +271,15 @@ namespace MLAPI
                     }
                     else
                     {
-                        //If someone is transitioning to this new format, then go ahead and populate the PlayerPrefab reference for them.
+                        // If someone is transitioning to this new format, then go ahead and populate the PlayerPrefab reference for them.
                         if (scanForPlayerPrefab && NetworkConfig.NetworkPrefabs[i].IsPlayer)
                         {
-                            //If we find a NetworkPrefab where IsPlayer is true and we have
-                            //no PlayerPrefab nor did we have one previously (i.e. we didn't just delete it),
-                            //then we want to set the default player prefab.  We also want to set the
-                            //previous player prefab value in the event the user decides to delete the
-                            //PlayerPrefab value from within the editor inspector view.
-                            //(See NtworkConfig.PreviousPlayerPrefab comments for more information)
+                            // If we find a NetworkPrefab where IsPlayer is true and we have
+                            // no PlayerPrefab nor did we have one previously (i.e. we didn't just delete it),
+                            // then we want to set the default player prefab.  We also want to set the
+                            // previous player prefab value in the event the user decides to delete the
+                            // PlayerPrefab value from within the editor inspector view.
+                            // (See NtworkConfig.PreviousPlayerPrefab comments for more information)
                             if (NetworkConfig.PreviousPlayerPrefab == null)
                             {
                                 NetworkConfig.PlayerPrefab = NetworkConfig.NetworkPrefabs[i].Prefab;
@@ -300,10 +300,10 @@ namespace MLAPI
                             }
                         }
 
-                        //Defautlt to the standard NetworkPrefab.Prefab's NetworkObject first
+                        // Defautlt to the standard NetworkPrefab.Prefab's NetworkObject first
                         var globalObjectIdHash = networkObject.GlobalObjectIdHash;
 
-                        //Now check to see if it has an override
+                        // Now check to see if it has an override
                         switch (NetworkConfig.NetworkPrefabs[i].Override)
                         {
                             case NetworkPrefabOverride.Prefab:
@@ -321,15 +321,15 @@ namespace MLAPI
                                 break;
                         }
 
-                        //Add to the NetworkPrefabOverrideLinks or handle a new (blank) entries
+                        // Add to the NetworkPrefabOverrideLinks or handle a new (blank) entries
                         if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(globalObjectIdHash))
                         {
                             NetworkConfig.NetworkPrefabOverrideLinks.Add(globalObjectIdHash, NetworkConfig.NetworkPrefabs[i]);
                         }
                         else
                         {
-                            //This happens when a new duplicate entry is created.
-                            //We just turn it into a new blank entry
+                            // This happens when a new duplicate entry is created.
+                            // We just turn it into a new blank entry
                             NetworkConfig.NetworkPrefabs[i] = new NetworkPrefab();
                         }
                     }
@@ -381,7 +381,7 @@ namespace MLAPI
                 return;
             }
 
-            //This 'if' should never enter
+            // This 'if' should never enter
             if (NetworkTickSystem != null)
             {
                 NetworkTickSystem.Dispose();
@@ -390,7 +390,7 @@ namespace MLAPI
 
             NetworkTickSystem = new NetworkTickSystem(NetworkConfig.NetworkTickIntervalSec);
 
-            //This should never happen, but in the event that it does there should be (at a minimum) a unity error logged.
+            // This should never happen, but in the event that it does there should be (at a minimum) a unity error logged.
             if (RpcQueueContainer != null)
             {
                 UnityEngine.Debug.LogError("Init was invoked, but rpcQueueContainer was already initialized! (destroying previous instance)");
@@ -398,8 +398,8 @@ namespace MLAPI
                 RpcQueueContainer = null;
             }
 
-            //The RpcQueueContainer must be initialized within the Init method ONLY
-            //It should ONLY be shutdown and destroyed in the Shutdown method (other than just above)
+            // The RpcQueueContainer must be initialized within the Init method ONLY
+            // It should ONLY be shutdown and destroyed in the Shutdown method (other than just above)
             RpcQueueContainer = new RpcQueueContainer(this);
 
             // Register INetworkUpdateSystem (always register this after rpcQueueContainer has been instantiated)
@@ -420,10 +420,10 @@ namespace MLAPI
                 SceneManager.SetCurrentSceneIndex();
             }
 
-            //This is used to remove entries not needed or invalid 
+            // This is used to remove entries not needed or invalid 
             var removeEmptyPrefabs = new List<int>();
 
-            //Build the NetworkPrefabOverrideLinks dictionary
+            // Build the NetworkPrefabOverrideLinks dictionary
             for (int i = 0; i < NetworkConfig.NetworkPrefabs.Count; i++)
             {
                 if (NetworkConfig.NetworkPrefabs[i] == null || NetworkConfig.NetworkPrefabs[i].Prefab == null)
@@ -433,11 +433,11 @@ namespace MLAPI
                         NetworkLog.LogWarning($"{nameof(NetworkPrefab)} cannot be null ({nameof(NetworkPrefab)} at index: {i})");
                     }
 
-                    //Provide the name of the prefab with issues so the user can more easily find the prefab and fix it
+                    // Provide the name of the prefab with issues so the user can more easily find the prefab and fix it
                     UnityEngine.Debug.LogWarning($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") will be removed and ignored.");
                     removeEmptyPrefabs.Add(i);
 
-                    //Ignore this entry due to the error (it will be removed during runtime)
+                    // Ignore this entry due to the error (it will be removed during runtime)
                     continue;
                 }
                 else if (NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>() == null)
@@ -447,18 +447,18 @@ namespace MLAPI
                         NetworkLog.LogWarning($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") is missing a {nameof(NetworkObject)} component");
                     }
 
-                    //Provide the name of the prefab with issues so the user can more easily find the prefab and fix it
+                    // Provide the name of the prefab with issues so the user can more easily find the prefab and fix it
                     UnityEngine.Debug.LogWarning($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") will be removed and ignored.");
                     removeEmptyPrefabs.Add(i);
 
-                    //Ignore this entry due to the error (it will be removed during runtime)
+                    // Ignore this entry due to the error (it will be removed during runtime)
                     continue;
                 }
 
-                //Get the default NetworkObject first
+                // Get the default NetworkObject first
                 var networkObject = NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>();
 
-                //Assign the appropriate GlobalObjectIdHash to the appropriate NetworkPrefab
+                // Assign the appropriate GlobalObjectIdHash to the appropriate NetworkPrefab
                 if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(networkObject.GlobalObjectIdHash))
                 {
                     switch (NetworkConfig.NetworkPrefabs[i].Override)
@@ -477,39 +477,39 @@ namespace MLAPI
                 }
                 else
                 {
-                    //This should never happen, but in the case it somehow does log an error and remove the duplicate entry
+                    // This should never happen, but in the case it somehow does log an error and remove the duplicate entry
                     UnityEngine.Debug.LogError($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") has a duplicate GlobalObjectIdHash {networkObject.GlobalObjectIdHash.ToString("X")} entry! Removing entry from list!");
                     removeEmptyPrefabs.Add(i);
                 }
             }
 
-            //If we have a player prefab, then we need to verify it is in the list of NetworkPrefabOverrideLinks for client side spawning.
-            if (NetworkConfig.PlayerPrefab != null )
+            // If we have a player prefab, then we need to verify it is in the list of NetworkPrefabOverrideLinks for client side spawning.
+            if (NetworkConfig.PlayerPrefab != null)
             {
                 var playerPrefabNetworkObject = NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>();
                 if (playerPrefabNetworkObject != null)
                 {
-                    //If we don't have a reference (i.e. someone didn't already add it to the NetworkPrefab list) 
+                    // If we don't have a reference (i.e. someone didn't already add it to the NetworkPrefab list) 
                     if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash))
                     {
-                        //Create a prefab entry
+                        // Create a prefab entry
                         var playerNetworkPrefab = new NetworkPrefab();
                         playerNetworkPrefab.Prefab = NetworkConfig.PlayerPrefab;
                         playerNetworkPrefab.IsPlayer = true;
 
-                        //Add it to the prefab list
+                        // Add it to the prefab list
                         NetworkConfig.NetworkPrefabs.Insert(0, playerNetworkPrefab);
 
-                        //assign its NetworkPrefabOverrideLink
+                        // assign its NetworkPrefabOverrideLink
                         NetworkConfig.NetworkPrefabOverrideLinks.Add(playerPrefabNetworkObject.GlobalObjectIdHash, playerNetworkPrefab);
                     }
                 }
             }
 
-            //Clear out anything that is invalid or not used (for invalid entries we already logged warnings to the user earlier)
+            // Clear out anything that is invalid or not used (for invalid entries we already logged warnings to the user earlier)
             foreach (var networkPrefabIndexToRemove in removeEmptyPrefabs)
             {
-               
+
                 NetworkConfig.NetworkPrefabs.RemoveAt(networkPrefabIndexToRemove);
             }
             removeEmptyPrefabs.Clear();

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -265,7 +265,7 @@ namespace MLAPI
                     }
                     else
                     {
-                        // Defautlt to the standard NetworkPrefab.Prefab's NetworkObject first
+                        // Default to the standard NetworkPrefab.Prefab's NetworkObject first
                         var globalObjectIdHash = networkObject.GlobalObjectIdHash;
 
                         // Now check to see if it has an override
@@ -292,8 +292,8 @@ namespace MLAPI
                         }
                         else
                         {
-                            // This happens when a new duplicate entry is created.
-                            // We just turn it into a new blank entry
+                            // Duplicate entries can happen when adding a new entry into a list of existing entries
+                            // Either this is user error or a new entry, either case we replace it with a new, blank, NetworkPrefab under this condition
                             NetworkConfig.NetworkPrefabs[i] = new NetworkPrefab();
                         }
                     }
@@ -404,7 +404,6 @@ namespace MLAPI
                     UnityEngine.Debug.LogWarning($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") will be removed and ignored.");
                     removeEmptyPrefabs.Add(i);
 
-                    // Ignore this entry due to the error (it will be removed during runtime)
                     continue;
                 }
                 else if (NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>() == null)
@@ -418,11 +417,9 @@ namespace MLAPI
                     UnityEngine.Debug.LogWarning($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") will be removed and ignored.");
                     removeEmptyPrefabs.Add(i);
 
-                    // Ignore this entry due to the error (it will be removed during runtime)
                     continue;
                 }
 
-                // Get the default NetworkObject first
                 var networkObject = NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>();
 
                 // Assign the appropriate GlobalObjectIdHash to the appropriate NetworkPrefab
@@ -445,7 +442,7 @@ namespace MLAPI
                 else
                 {
                     // This should never happen, but in the case it somehow does log an error and remove the duplicate entry
-                    UnityEngine.Debug.LogError($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") has a duplicate GlobalObjectIdHash {networkObject.GlobalObjectIdHash.ToString("X")} entry! Removing entry from list!");
+                    UnityEngine.Debug.LogError($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") has a duplicate {nameof(NetworkObject.GlobalObjectIdHash)} {networkObject.GlobalObjectIdHash} entry! Removing entry from list!");
                     removeEmptyPrefabs.Add(i);
                 }
             }
@@ -459,14 +456,10 @@ namespace MLAPI
                     //In the event there is no NetworkPrefab entry (i.e. no override for default player prefab)
                     if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(playerPrefabNetworkObject.GlobalObjectIdHash))
                     {
-                        // Create a prefab entry
+                        //Then add a new entry for the player prefab
                         var playerNetworkPrefab = new NetworkPrefab();
                         playerNetworkPrefab.Prefab = NetworkConfig.PlayerPrefab;                        
-
-                        // Add it to the prefab list
                         NetworkConfig.NetworkPrefabs.Insert(0, playerNetworkPrefab);
-
-                        // assign its NetworkPrefabOverrideLink
                         NetworkConfig.NetworkPrefabOverrideLinks.Add(playerPrefabNetworkObject.GlobalObjectIdHash, playerNetworkPrefab);
                     }
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -244,6 +244,7 @@ namespace MLAPI
                 };
             }
 
+            //Should we see if there is already a defined player prefab in the Network prefab list?
             var scanForPlayerPrefab = (NetworkConfig.PlayerPrefab == null && NetworkConfig.CreatePlayerPrefab);
 
             //Clear this out and rebuild
@@ -289,6 +290,7 @@ namespace MLAPI
 
                         var globalObjectIdHash = networkObject.GlobalObjectIdHash;
 
+                        //Check to see if the NetworkPrefab has an override
                         switch (NetworkConfig.NetworkPrefabs[i].Override)
                         {
                             case NetworkPrefabOverride.Prefab:

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -21,7 +21,7 @@ using MLAPI.Exceptions;
 using MLAPI.Transports.Tasks;
 using MLAPI.Messaging.Buffering;
 using Unity.Profiling;
-using UnityEditor.VersionControl;
+//using UnityEditor.VersionControl;
 
 namespace MLAPI
 {
@@ -252,7 +252,7 @@ namespace MLAPI
             //If true, check to see if there is a defined player prefab in the Network prefab list
             //This helps migrate v0.1.0 projects (i.e. no PlayerPrefab was assigned) as well as helps detect
             //specific interface related issues related to the NetworkPrefabs list.
-            var scanForPlayerPrefab = (NetworkConfig.PlayerPrefab == null && NetworkConfig.CreatePlayerPrefab);
+            var scanForPlayerPrefab = NetworkConfig.PlayerPrefab == null;
 
             //During OnValidate we will always clear out NetworkPrefabOverrideLinks and rebuild it in order to
             //detect specific edge case scenarios (See NtworkConfig.PreviousPlayerPrefab comments)
@@ -486,7 +486,7 @@ namespace MLAPI
             }
 
             //If we have a player prefab, then we need to verify it is in the list of NetworkPrefabOverrideLinks for client side spawning.
-            if (NetworkConfig.PlayerPrefab != null && NetworkConfig.CreatePlayerPrefab)
+            if (NetworkConfig.PlayerPrefab != null )
             {
                 var playerPrefabNetworkObject = NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>();
                 if (playerPrefabNetworkObject != null)
@@ -737,7 +737,7 @@ namespace MLAPI
             }
             else
             {
-                HandleApproval(ServerClientId, NetworkConfig.CreatePlayerPrefab, null, true, null, null);
+                HandleApproval(ServerClientId, NetworkConfig.PlayerPrefab != null, null, true, null, null);
             }
 
             SpawnManager.ServerSpawnSceneObjectsOnStartSweep();

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -457,7 +457,7 @@ namespace MLAPI
                 if (playerPrefabNetworkObject != null)
                 {
                     //In the event there is no NetworkPrefab entry (i.e. no override for default player prefab)
-                    if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash))
+                    if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(playerPrefabNetworkObject.GlobalObjectIdHash))
                     {
                         // Create a prefab entry
                         var playerNetworkPrefab = new NetworkPrefab();

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -423,6 +423,9 @@ namespace MLAPI
             // This is used to remove entries not needed or invalid 
             var removeEmptyPrefabs = new List<int>();
 
+            // Always clear our prefab override links before building
+            NetworkConfig.NetworkPrefabOverrideLinks.Clear();
+
             // Build the NetworkPrefabOverrideLinks dictionary
             for (int i = 0; i < NetworkConfig.NetworkPrefabs.Count; i++)
             {

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -4,9 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using UnityEngine;
-using System.Linq;
 using MLAPI.Logging;
-using UnityEngine.SceneManagement;
 using MLAPI.Configuration;
 using MLAPI.Internal;
 using MLAPI.Profiling;
@@ -21,7 +19,7 @@ using MLAPI.Exceptions;
 using MLAPI.Transports.Tasks;
 using MLAPI.Messaging.Buffering;
 using Unity.Profiling;
-//using UnityEditor.VersionControl;
+
 
 namespace MLAPI
 {

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -156,7 +156,7 @@ namespace MLAPI.Messaging
                             var networkObject = NetworkManager.SpawnManager.CreateLocalNetworkObject(softSync, prefabHash, ownerId, parentNetworkId, pos, rot);
                             if (networkObject == null)
                             {
-                                //This will prevent one misconfigured issue (or more) from breaking the entire loading process.
+                                // This will prevent one misconfigured issue (or more) from breaking the entire loading process.
                                 Debug.LogError($"Failed to spawn NetowrkObject for Hash {prefabHash}, ignoring and continuing to load.");
                                 continue;
                             }

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -154,12 +154,6 @@ namespace MLAPI.Messaging
                             }
 
                             var networkObject = NetworkManager.SpawnManager.CreateLocalNetworkObject(softSync, prefabHash, ownerId, parentNetworkId, pos, rot);
-                            if (networkObject == null)
-                            {
-                                // This will prevent one misconfigured issue (or more) from breaking the entire loading process.
-                                Debug.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {prefabHash}, ignoring and continuing to load.");
-                                continue;
-                            }
                             NetworkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerId, continuationStream, false, 0, true, false);
 
                             Queue<BufferManager.BufferedMessage> bufferQueue = NetworkManager.BufferManager.ConsumeBuffersForNetworkId(networkId);

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -157,7 +157,7 @@ namespace MLAPI.Messaging
                             if (networkObject == null)
                             {
                                 // This will prevent one misconfigured issue (or more) from breaking the entire loading process.
-                                Debug.LogError($"Failed to spawn NetowrkObject for Hash {prefabHash}, ignoring and continuing to load.");
+                                Debug.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {prefabHash}, ignoring and continuing to load.");
                                 continue;
                             }
                             NetworkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerId, continuationStream, false, 0, true, false);

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -81,7 +81,7 @@ namespace MLAPI.Messaging
                 }
                 else
                 {
-                    NetworkManager.HandleApproval(clientId, NetworkManager.NetworkConfig.CreatePlayerPrefab, null, true, null, null);
+                    NetworkManager.HandleApproval(clientId, NetworkManager.NetworkConfig.PlayerPrefab != null, null, true, null, null);
                 }
             }
 #if DEVELOPMENT_BUILD || UNITY_EDITOR

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -154,6 +154,12 @@ namespace MLAPI.Messaging
                             }
 
                             var networkObject = NetworkManager.Singleton.SpawnManager.CreateLocalNetworkObject(softSync, prefabHash, ownerId, parentNetworkId, pos, rot);
+                            if (networkObject == null)
+                            {
+                                //This will prevent one misconfigured issues from breaking the entire loading process.
+                                Debug.LogError($"Failed to spawn NetowrkObject for Hash {prefabHash}, ignoring and continuing to load.");
+                                continue;
+                            }
                             NetworkManager.Singleton.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerId, continuationStream, false, 0, true, false);
 
                             Queue<BufferManager.BufferedMessage> bufferQueue = NetworkManager.BufferManager.ConsumeBuffersForNetworkId(networkId);

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -156,7 +156,7 @@ namespace MLAPI.Messaging
                             var networkObject = NetworkManager.Singleton.SpawnManager.CreateLocalNetworkObject(softSync, prefabHash, ownerId, parentNetworkId, pos, rot);
                             if (networkObject == null)
                             {
-                                //This will prevent one misconfigured issues from breaking the entire loading process.
+                                //This will prevent one misconfigured issue (or more) from breaking the entire loading process.
                                 Debug.LogError($"Failed to spawn NetowrkObject for Hash {prefabHash}, ignoring and continuing to load.");
                                 continue;
                             }

--- a/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -389,13 +389,6 @@ namespace MLAPI.SceneManagement
                     }
 
                     var networkObject = m_NetworkManager.SpawnManager.CreateLocalNetworkObject(true, prefabHash, ownerClientId, parentNetworkId, position, rotation);
-                    if (networkObject == null)
-                    {
-                        // This will prevent one misconfigured issue (or more) from breaking the entire loading process.
-                        Debug.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {prefabHash}, ignoring and continuing to load.");
-                        continue;
-                    }
-
                     m_NetworkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, true, isPlayerObject, ownerClientId, objectStream, false, 0, true, false);
 
                     var bufferQueue = m_NetworkManager.BufferManager.ConsumeBuffersForNetworkId(networkId);

--- a/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -304,31 +304,31 @@ namespace MLAPI.SceneManagement
                                 }
                                 else
                                 {
-                                    //We do have a parent
+                                    // We do have a parent
                                     writer.WriteBool(true);
-                                    //Write the parent's NetworkObjectId to be used for linking back to the child
+                                    // Write the parent's NetworkObjectId to be used for linking back to the child
                                     writer.WriteUInt64Packed(parentNetworkObject.NetworkObjectId);
                                 }
 
                                 writer.WriteUInt32Packed(newSceneObjects[i].GlobalObjectIdHash);
                                 if (newSceneObjects[i].IncludeTransformWhenSpawning == null || newSceneObjects[i].IncludeTransformWhenSpawning(newSceneObjects[i].OwnerClientId))
                                 {
-                                    //Set the position and rotation data marker to true (i.e. flag to know, when reading from the stream, that postion and roation data follows).
+                                    // Set the position and rotation data marker to true (i.e. flag to know, when reading from the stream, that postion and roation data follows).
                                     writer.WriteBool(true);
 
-                                    //Write position
+                                    // Write position
                                     writer.WriteSinglePacked(newSceneObjects[i].transform.position.x);
                                     writer.WriteSinglePacked(newSceneObjects[i].transform.position.y);
                                     writer.WriteSinglePacked(newSceneObjects[i].transform.position.z);
 
-                                    //Write rotation
+                                    // Write rotation
                                     writer.WriteSinglePacked(newSceneObjects[i].transform.rotation.eulerAngles.x);
                                     writer.WriteSinglePacked(newSceneObjects[i].transform.rotation.eulerAngles.y);
                                     writer.WriteSinglePacked(newSceneObjects[i].transform.rotation.eulerAngles.z);
                                 }
                                 else
                                 {
-                                    //Set the position and rotation data marker to false (i.e. flag to know, when reading from the stream, that postion and roation data *was not included*)
+                                    // Set the position and rotation data marker to false (i.e. flag to know, when reading from the stream, that postion and roation data *was not included*)
                                     writer.WriteBool(false);
                                 }
 
@@ -344,7 +344,7 @@ namespace MLAPI.SceneManagement
                 }
             }
 
-            //Tell server that scene load is completed
+            // Tell server that scene load is completed
             if (m_NetworkManager.IsHost)
             {
                 OnClientSwitchSceneCompleted(m_NetworkManager.LocalClientId, switchSceneGuid);
@@ -381,7 +381,7 @@ namespace MLAPI.SceneManagement
                     Vector3? position = null;
                     Quaternion? rotation = null;
 
-                    //Check to see if we have position and rotation values that follows
+                    // Check to see if we have position and rotation values that follows
                     if (reader.ReadBool())
                     {
                         position = new Vector3(reader.ReadSinglePacked(), reader.ReadSinglePacked(), reader.ReadSinglePacked());
@@ -391,7 +391,7 @@ namespace MLAPI.SceneManagement
                     var networkObject = m_NetworkManager.SpawnManager.CreateLocalNetworkObject(true, prefabHash, ownerClientId, parentNetworkId, position, rotation);
                     if (networkObject == null)
                     {
-                        //This will prevent one misconfigured issue (or more) from breaking the entire loading process.
+                        // This will prevent one misconfigured issue (or more) from breaking the entire loading process.
                         Debug.LogError($"Failed to spawn NetowrkObject for Hash {prefabHash}, ignoring and continuing to load.");
                         continue;
                     }
@@ -432,7 +432,7 @@ namespace MLAPI.SceneManagement
         {
             if (switchSceneGuid == Guid.Empty)
             {
-                //If Guid is empty it means the client has loaded the start scene of the server and the server would never have a switchSceneProgresses created for the start scene.
+                // If Guid is empty it means the client has loaded the start scene of the server and the server would never have a switchSceneProgresses created for the start scene.
                 return;
             }
 

--- a/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -381,6 +381,13 @@ namespace MLAPI.SceneManagement
                     }
 
                     var networkObject = NetworkManager.Singleton.SpawnManager.CreateLocalNetworkObject(true, prefabHash, ownerClientId, parentNetworkId, position, rotation);
+                    if (networkObject == null)
+                    {
+                        //This will prevent one misconfigured issues from breaking the entire loading process.
+                        Debug.LogError($"Failed to spawn NetowrkObject for Hash {prefabHash}, ignoring and continuing to load.");
+                        continue;
+                    }
+
                     NetworkManager.Singleton.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, true, isPlayerObject, ownerClientId, objectStream, false, 0, true, false);
 
                     var bufferQueue = NetworkManager.Singleton.BufferManager.ConsumeBuffersForNetworkId(networkId);

--- a/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -392,7 +392,7 @@ namespace MLAPI.SceneManagement
                     if (networkObject == null)
                     {
                         // This will prevent one misconfigured issue (or more) from breaking the entire loading process.
-                        Debug.LogError($"Failed to spawn NetowrkObject for Hash {prefabHash}, ignoring and continuing to load.");
+                        Debug.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {prefabHash}, ignoring and continuing to load.");
                         continue;
                     }
 

--- a/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -383,7 +383,7 @@ namespace MLAPI.SceneManagement
                     var networkObject = NetworkManager.Singleton.SpawnManager.CreateLocalNetworkObject(true, prefabHash, ownerClientId, parentNetworkId, position, rotation);
                     if (networkObject == null)
                     {
-                        //This will prevent one misconfigured issues from breaking the entire loading process.
+                        //This will prevent one misconfigured issue (or more) from breaking the entire loading process.
                         Debug.LogError($"Failed to spawn NetowrkObject for Hash {prefabHash}, ignoring and continuing to load.");
                         continue;
                     }

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -212,7 +212,7 @@ namespace MLAPI.Spawning
                 // If the prefab hash has a registered INetworkPrefabInstanceHandler derived class 
                 if (NetworkManager.PrefabHandler.ContainsHandler(prefabHash))
                 {
-                    //Let the handler spawn the NetworkObject
+                    // Let the handler spawn the NetworkObject
                     var networkObject = NetworkManager.PrefabHandler.HandleNetworkPrefabSpawn(prefabHash, ownerClientId, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity));
 
                     if (parentNetworkObject != null)
@@ -229,7 +229,7 @@ namespace MLAPI.Spawning
                 }
                 else
                 {
-                    //See if there is a valid registered NetworkPrefabOverrideLink associated with the provided prefabHash
+                    // See if there is a valid registered NetworkPrefabOverrideLink associated with the provided prefabHash
                     GameObject networkPrefabReference = null;
                     if(NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(prefabHash))
                     {
@@ -246,7 +246,7 @@ namespace MLAPI.Spawning
                         }
                     }
 
-                    //If not, then there is an issue (user possibly didn't register the prefab properly?)
+                    // If not, then there is an issue (user possibly didn't register the prefab properly?)
                     if (networkPrefabReference == null)
                     {
                         if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
@@ -257,7 +257,7 @@ namespace MLAPI.Spawning
                         return null;
                     }
 
-                    //Otherwise, instantiate an instance of the NetworkPrefab linked to the prefabHash
+                    // Otherwise, instantiate an instance of the NetworkPrefab linked to the prefabHash
                     var networkObject = ((position == null && rotation == null) ? UnityEngine.Object.Instantiate(networkPrefabReference) : UnityEngine.Object.Instantiate(networkPrefabReference, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity))).GetComponent<NetworkObject>();
 
                     if (parentNetworkObject != null)

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -221,48 +221,20 @@ namespace MLAPI.Spawning
                 else
                 {
                     GameObject networkPrefabReference = null;
-                    if(NetworkManager.NetworkConfig.HashedNetworkPrefabs.ContainsKey(prefabHash))
+                    if(NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(prefabHash))
                     {
-                        switch (NetworkManager.NetworkConfig.HashedNetworkPrefabs[prefabHash].Override)
+                        switch (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[prefabHash].Override)
                         {
                             default:
-                            case NetworkPrefabOverride.Unset:
-                                networkPrefabReference = NetworkManager.NetworkConfig.HashedNetworkPrefabs[prefabHash].Prefab;
+                            case NetworkPrefabOverride.None:
+                                networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[prefabHash].Prefab;
                                 break;
                             case NetworkPrefabOverride.Hash:
                             case NetworkPrefabOverride.Prefab:
-                                networkPrefabReference = NetworkManager.NetworkConfig.HashedNetworkPrefabs[prefabHash].OverridingTargetPrefab;
+                                networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[prefabHash].OverridingTargetPrefab;
                                 break;
                         }
                     }
-
-                    //for (int i = 0; networkPrefabReference == null && i < NetworkManager.NetworkConfig.NetworkPrefabs.Count; i++)
-                    //{
-                    //    var element = NetworkManager.NetworkConfig.NetworkPrefabs[i];
-                        
-                    //    switch (element.Override)
-                    //    {
-                    //        default:
-                    //        case NetworkPrefabOverride.Unset:
-                    //            if (element.Hash == prefabHash)
-                    //            {
-                    //                networkPrefabReference = element.Prefab;
-                    //            }
-                    //            break;
-                    //        case NetworkPrefabOverride.Prefab:
-                    //            if (element.OverridingSourcePrefab.GetComponent<NetworkObject>().GlobalObjectIdHash == prefabHash)
-                    //            {
-                    //                networkPrefabReference = element.OverridingTargetPrefab;
-                    //            }
-                    //            break;
-                    //        case NetworkPrefabOverride.Hash:
-                    //            if (element.OverridingSourceHash == prefabHash)
-                    //            {
-                    //                networkPrefabReference = element.OverridingTargetPrefab;
-                    //            }
-                    //            break;
-                    //    }
-                    //}
 
                     if (networkPrefabReference == null)
                     {

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -182,15 +182,8 @@ namespace MLAPI.Spawning
         }
 
         /// <summary>
-        /// Only run on the client 
+        /// Should only run on the client 
         /// </summary>
-        /// <param name="softCreate"></param>
-        /// <param name="prefabHash"></param>
-        /// <param name="ownerClientId"></param>
-        /// <param name="parentNetworkId"></param>
-        /// <param name="position"></param>
-        /// <param name="rotation"></param>
-        /// <returns></returns>
         internal NetworkObject CreateLocalNetworkObject(bool softCreate, uint prefabHash, ulong ownerClientId, ulong? parentNetworkId, Vector3? position, Quaternion? rotation)
         {
             NetworkObject parentNetworkObject = null;

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -58,34 +58,6 @@ namespace MLAPI.Spawning
         }
 
         /// <summary>
-        /// Gets the prefab index of a given prefab hash
-        /// </summary>
-        /// <param name="hash">The hash of the prefab</param>
-        /// <returns>The index of the prefab</returns>
-        public int GetNetworkPrefabIndexOfHash(uint hash)
-        {
-            for (int i = 0; i < NetworkManager.NetworkConfig.NetworkPrefabs.Count; i++)
-            {
-                if (NetworkManager.NetworkConfig.NetworkPrefabs[i].Hash == hash)
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        /// <summary>
-        /// Returns the prefab hash for the NetworkPrefab with a given index
-        /// </summary>
-        /// <param name="index">The NetworkPrefab index</param>
-        /// <returns>The prefab hash for the given prefab index</returns>
-        public uint GetPrefabHashFromIndex(int index)
-        {
-            return NetworkManager.NetworkConfig.NetworkPrefabs[index].Hash;
-        }
-
-        /// <summary>
         /// Returns the local player object or null if one does not exist
         /// </summary>
         /// <returns>The local player object or null if one does not exist</returns>
@@ -273,7 +245,7 @@ namespace MLAPI.Spawning
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
-                        NetworkLog.LogError($"{nameof(NetworkPrefab)} hash was not found! In-Scene placed NetworkObject soft synchronization failure for Hash: {prefabHash.ToString("X")}!");
+                        NetworkLog.LogError($"{nameof(NetworkPrefab)} hash was not found! In-Scene placed {nameof(NetworkObject)} soft synchronization failure for Hash: {prefabHash}!");
                     }
                     return null;
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -220,20 +220,61 @@ namespace MLAPI.Spawning
                 }
                 else
                 {
-                    var prefabIndex = GetNetworkPrefabIndexOfHash(prefabHash);
+                    GameObject networkPrefabReference = null;
+                    if(NetworkManager.NetworkConfig.HashedNetworkPrefabs.ContainsKey(prefabHash))
+                    {
+                        switch (NetworkManager.NetworkConfig.HashedNetworkPrefabs[prefabHash].Override)
+                        {
+                            default:
+                            case NetworkPrefabOverride.Unset:
+                                networkPrefabReference = NetworkManager.NetworkConfig.HashedNetworkPrefabs[prefabHash].Prefab;
+                                break;
+                            case NetworkPrefabOverride.Hash:
+                            case NetworkPrefabOverride.Prefab:
+                                networkPrefabReference = NetworkManager.NetworkConfig.HashedNetworkPrefabs[prefabHash].OverridingTargetPrefab;
+                                break;
+                        }
+                    }
 
-                    if (prefabIndex < 0)
+                    //for (int i = 0; networkPrefabReference == null && i < NetworkManager.NetworkConfig.NetworkPrefabs.Count; i++)
+                    //{
+                    //    var element = NetworkManager.NetworkConfig.NetworkPrefabs[i];
+                        
+                    //    switch (element.Override)
+                    //    {
+                    //        default:
+                    //        case NetworkPrefabOverride.Unset:
+                    //            if (element.Hash == prefabHash)
+                    //            {
+                    //                networkPrefabReference = element.Prefab;
+                    //            }
+                    //            break;
+                    //        case NetworkPrefabOverride.Prefab:
+                    //            if (element.OverridingSourcePrefab.GetComponent<NetworkObject>().GlobalObjectIdHash == prefabHash)
+                    //            {
+                    //                networkPrefabReference = element.OverridingTargetPrefab;
+                    //            }
+                    //            break;
+                    //        case NetworkPrefabOverride.Hash:
+                    //            if (element.OverridingSourceHash == prefabHash)
+                    //            {
+                    //                networkPrefabReference = element.OverridingTargetPrefab;
+                    //            }
+                    //            break;
+                    //    }
+                    //}
+
+                    if (networkPrefabReference == null)
                     {
                         if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                         {
-                            NetworkLog.LogError($"Failed to create object locally. [{nameof(prefabHash)}={prefabHash}]. Hash could not be found. Is the prefab registered?");
+                            NetworkLog.LogError($"Failed to create object locally. [{nameof(prefabHash)}={prefabHash}]. {nameof(NetworkPrefab)} could not be found. Is the prefab registered with {nameof(NetworkManager)}?");
                         }
 
                         return null;
                     }
 
-                    var prefab = NetworkManager.NetworkConfig.NetworkPrefabs[prefabIndex].Prefab;
-                    var networkObject = ((position == null && rotation == null) ? UnityEngine.Object.Instantiate(prefab) : UnityEngine.Object.Instantiate(prefab, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity))).GetComponent<NetworkObject>();
+                    var networkObject = ((position == null && rotation == null) ? UnityEngine.Object.Instantiate(networkPrefabReference) : UnityEngine.Object.Instantiate(networkPrefabReference, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity))).GetComponent<NetworkObject>();
 
                     if (parentNetworkObject != null)
                     {

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/GlobalObjectIdHash/NetworkPrefabGlobalObjectIdHashTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/GlobalObjectIdHash/NetworkPrefabGlobalObjectIdHashTests.cs
@@ -61,9 +61,9 @@ namespace MLAPI.RuntimeTests
             Assert.That(networkManager.NetworkConfig.NetworkPrefabs.Count, Is.GreaterThan(1));
 
             var hashSet = new HashSet<uint>();
-            foreach (var networkPrefab in networkManager.NetworkConfig.NetworkPrefabs)
+            foreach (var networkPrefab in networkManager.NetworkConfig.NetworkPrefabOverrideLinks)
             {
-                var idHash = networkPrefab.Hash;
+                var idHash = networkPrefab.Key;
                 Assert.That(idHash, Is.Not.EqualTo(0));
                 Assert.That(hashSet.Contains(idHash), Is.False);
                 hashSet.Add(idHash);

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkManagerHelper.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkManagerHelper.cs
@@ -74,7 +74,6 @@ namespace MLAPI.RuntimeTests
 
                 NetworkManagerObject.NetworkConfig = new Configuration.NetworkConfig
                 {
-                    CreatePlayerPrefab = false,
                     EnableSceneManagement = false,
                     RegisteredScenes = new List<string>(){SceneManager.GetActiveScene().name}
                 };

--- a/testproject/Assets/ManualTests/RpcTesting.unity
+++ b/testproject/Assets/ManualTests/RpcTesting.unity
@@ -422,7 +422,7 @@ PrefabInstance:
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
@@ -432,7 +432,7 @@ PrefabInstance:
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
@@ -487,7 +487,7 @@ PrefabInstance:
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
@@ -808,11 +808,18 @@ MonoBehaviour:
     RegisteredScenes:
     - RpcTesting
     AllowRuntimeSceneChanges: 0
+    PlayerPrefab: {fileID: 4700706668509470175, guid: 7eeaaf9e50c0afc4dab93584a54fb0d6,
+      type: 3}
     NetworkPrefabs:
     - Prefab: {fileID: 4700706668509470175, guid: 7eeaaf9e50c0afc4dab93584a54fb0d6,
         type: 3}
-      IsPlayer: 1
-    PlayerPrefabHash: 315939022
+      Override: 0
+      OverridingSourcePrefab: {fileID: 4700706668509470175, guid: 7eeaaf9e50c0afc4dab93584a54fb0d6,
+        type: 3}
+      OverridingSourceHash: 0
+      OverridingTargetPrefab: {fileID: 8685790303553767886, guid: 96e0a72e30d0c46c8a5c9a750e8f5807,
+        type: 3}
+      IsPlayer: 0
     CreatePlayerPrefab: 1
     ReceiveTickrate: 64
     NetworkTickIntervalSec: 0.05
@@ -827,7 +834,6 @@ MonoBehaviour:
     EnsureNetworkVariableLengthSafety: 0
     EnableSceneManagement: 1
     ForceSamePrefabs: 1
-    UsePrefabSync: 0
     RecycleNetworkIds: 1
     NetworkIdRecycleDelay: 120
     RpcHashSize: 0


### PR DESCRIPTION
This is the first pass changes required to implement MTT-640.
The default player prefab is now a directly assigned value as opposed to a checkbox in the network prefab list.
The default player prefab has to also be included in the NetworkPrefab list (this is so the default player prefab can be overridden too)
NetworkPrefab entries can be overridden and directly assigned alternate prefabs for clients to spawn.
The source prefab (what the server uses) can be a prefab reference or a prefab hash.