### PR TITLE
chore: fix namespace for ProfilerTests

### DIFF
--- a/com.unity.multiplayer.mlapi/Tests/Editor/ProfilerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/ProfilerTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using MLAPI.Profiling;
 using NUnit.Framework;
 
-namespace MLAPI.RuntimeTests
+namespace MLAPI.EditorTests
 {
     public class TestTransport : ITransportProfilerData
     {


### PR DESCRIPTION
it should be under `MLAPI.EditorTests` namespace.