### PR TITLE
feat: Add way to override GlobalObjectIdHash

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -42,7 +42,6 @@ namespace MLAPI
 
         [HideInInspector]
         [SerializeField]
-        [FormerlySerializedAs("GlobalObjectIdHash")]
         private uint globalObjectIdHash;
 
 #if UNITY_EDITOR


### PR DESCRIPTION
This adds a way to override the GlobalObjectIdHash. This allows us to perfectly mimic how object replication works in a build but in a singleton-less single process environment without using any abstractions in between that has to be tested.

It is a requirement for full fledged SceneObject testing where every part of the library is used as it will be in production.

It does not affect the core library or users.

It reduces the used bit size of the GlobalObjectIdHash from 32 to 31 bits and uses the first bit as a flag. This flag's only purpose is to indicate internally to the generator if the GlobalObjectIdHash is "naturally generated", which means that the MLAPI generator is responsible for generating it and keeping it up to date. Or if it's "overriden", which means the MLAPI generator should not re-generate it.

The first bit (override bit) is not exposed in the final version that every part of the library (except the generator itself) and/or users use. This means that a value that is "naturally generated" can be copied from one object, then set onto that object. Their underlying values will not be same (one will have a 0 as first bit, while the other will have a 1 as first bit) but they will be exposed identically to everything trying to access it.
