### PR TITLE
fix: globalobjectidhash printing in editor, remove istestrun flag

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -209,8 +209,6 @@ namespace MLAPI
         internal static event Action OnSingletonReady;
 
 #if UNITY_EDITOR
-        internal static bool IsTestRun = false;
-
         private void OnValidate()
         {
             if (NetworkConfig == null)
@@ -321,7 +319,7 @@ namespace MLAPI
             SpawnManager = new NetworkSpawnManager(this);
 
             CustomMessagingManager = new CustomMessagingManager(this);
-            
+
             BufferManager = new BufferManager(this);
 
             SceneManager = new NetworkSceneManager(this);
@@ -383,7 +381,7 @@ namespace MLAPI
                 SceneManager.SetCurrentSceneIndex();
             }
 
-            // This is used to remove entries not needed or invalid 
+            // This is used to remove entries not needed or invalid
             var removeEmptyPrefabs = new List<int>();
 
             // Always clear our prefab override links before building
@@ -457,7 +455,7 @@ namespace MLAPI
                     {
                         //Then add a new entry for the player prefab
                         var playerNetworkPrefab = new NetworkPrefab();
-                        playerNetworkPrefab.Prefab = NetworkConfig.PlayerPrefab;                        
+                        playerNetworkPrefab.Prefab = NetworkConfig.PlayerPrefab;
                         NetworkConfig.NetworkPrefabs.Insert(0, playerNetworkPrefab);
                         NetworkConfig.NetworkPrefabOverrideLinks.Add(playerPrefabNetworkObject.GlobalObjectIdHash, playerNetworkPrefab);
                     }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -26,11 +26,13 @@ namespace MLAPI
 #if UNITY_EDITOR
         private void OnValidate()
         {
+            // do NOT regenerate GlobalObjectIdHash for NetworkPrefabs while Editor is in PlayMode
             if (UnityEditor.EditorApplication.isPlaying && !string.IsNullOrEmpty(gameObject.scene.name))
             {
                 return;
             }
 
+            // do NOT regenerate GlobalObjectIdHash if the Editor is transitining into or out of the PlayMode
             if (!UnityEditor.EditorApplication.isPlaying && UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
             {
                 return;

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -6,7 +6,6 @@ using MLAPI.Configuration;
 using MLAPI.Exceptions;
 using MLAPI.Hashing;
 using MLAPI.Logging;
-using MLAPI.Messaging;
 using MLAPI.Serialization.Pooled;
 using MLAPI.Transports;
 using UnityEngine;
@@ -27,9 +26,13 @@ namespace MLAPI
 #if UNITY_EDITOR
         private void OnValidate()
         {
-            if (UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode && !NetworkManager.IsTestRun)
+            if (UnityEditor.EditorApplication.isPlaying && !string.IsNullOrEmpty(gameObject.scene.name))
             {
-                // do NOT override GlobalObjectIdHash while getting into PlayMode in the Editor
+                return;
+            }
+
+            if (UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode && !UnityEditor.EditorApplication.isPlaying)
+            {
                 return;
             }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -32,7 +32,7 @@ namespace MLAPI
                 return;
             }
 
-            // do NOT regenerate GlobalObjectIdHash if the Editor is transitining into or out of the PlayMode
+            // do NOT regenerate GlobalObjectIdHash if Editor is transitining into or out of PlayMode
             if (!UnityEditor.EditorApplication.isPlaying && UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
             {
                 return;

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -31,7 +31,7 @@ namespace MLAPI
                 return;
             }
 
-            if (UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode && !UnityEditor.EditorApplication.isPlaying)
+            if (!UnityEditor.EditorApplication.isPlaying && UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
             {
                 return;
             }

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/GlobalObjectIdHash/NetworkPrefabGlobalObjectIdHashTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/GlobalObjectIdHash/NetworkPrefabGlobalObjectIdHashTests.cs
@@ -25,8 +25,6 @@ namespace MLAPI.RuntimeTests
         [UnitySetUp]
         public IEnumerator Setup()
         {
-            NetworkManager.IsTestRun = true;
-
             SceneManager.sceneLoaded += OnSceneLoaded;
 
             var execAssembly = Assembly.GetExecutingAssembly();
@@ -45,8 +43,6 @@ namespace MLAPI.RuntimeTests
             {
                 yield return SceneManager.UnloadSceneAsync(m_TestScene);
             }
-
-            NetworkManager.IsTestRun = false;
         }
 
         [Test]


### PR DESCRIPTION
removes `bool NetworkManager.IsTestRun` entirely as it is no longer needed.
fixes `GlobalObjectIdHash` consistency issue in the Editor (as we found with Noel during tests).