### PR TITLE
feat: implement temporary globalobjectidhash override

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -24,8 +24,20 @@ namespace MLAPI
         internal uint GlobalObjectIdHash;
 
 #if UNITY_EDITOR
+        // HEAD: TEST ONLY TEMP IMPL
+        internal uint TempGlobalObjectIdHashOverride = 0;
+        // TAIL: TEST ONLY TEMP IMPL
+
         private void OnValidate()
         {
+            // HEAD: TEST ONLY TEMP IMPL
+            if (TempGlobalObjectIdHashOverride != 0)
+            {
+                GlobalObjectIdHash = TempGlobalObjectIdHashOverride;
+                return;
+            }
+            // TAIL: TEST ONLY TEMP IMPL
+
             // do NOT regenerate GlobalObjectIdHash for NetworkPrefabs while Editor is in PlayMode
             if (UnityEditor.EditorApplication.isPlaying && !string.IsNullOrEmpty(gameObject.scene.name))
             {

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -24,19 +24,19 @@ namespace MLAPI
         internal uint GlobalObjectIdHash;
 
 #if UNITY_EDITOR
-        // HEAD: TEST ONLY TEMP IMPL
+        // HEAD: DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED
         internal uint TempGlobalObjectIdHashOverride = 0;
-        // TAIL: TEST ONLY TEMP IMPL
+        // TAIL: DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED
 
         private void OnValidate()
         {
-            // HEAD: TEST ONLY TEMP IMPL
+            // HEAD: DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED
             if (TempGlobalObjectIdHashOverride != 0)
             {
                 GlobalObjectIdHash = TempGlobalObjectIdHashOverride;
                 return;
             }
-            // TAIL: TEST ONLY TEMP IMPL
+            // TAIL: DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED
 
             // do NOT regenerate GlobalObjectIdHash for NetworkPrefabs while Editor is in PlayMode
             if (UnityEditor.EditorApplication.isPlaying && !string.IsNullOrEmpty(gameObject.scene.name))


### PR DESCRIPTION
as per our internal conversation and alignment, and as a follow-up on recent singleton removal PRs, this PR provides a minimal temporary solution to override a `NetworkObject`s `GlobalObjectIdHash` field.
this will unblock side-by-side testing in testrunner (+ over yamato ci) with multiple `NetworkManager` instances, potentially with a host/server and a client connected to it.

**this temporary solution should not be used outside unit testing scope, and it will eventually be removed completely** when we implement a similar `NetworkObject` linking feature on top of `GlobalObjectIdHash` (similar to what we had with `NetworkPrefabHandlers`) that sits a layer above `GlobalObjectIdHash` and doesn't even touch `GlobalObjectIdHash` printing logic at all.

a simple example use (pseudo-code):
```cs
var networkObjects = FindObjectsOfType<NetworkObject>();
foreach (var networkObject in networkObjects)
{
    // if this is a scene object, duplicate it to create an instance for other `NetworkManager` instance to use during tests
    if (networkObject.IsSceneObject == null)
    {
        // Clone the original `NetworkObject` instance
        var cloneNetworkObject = Instantiate(networkObject.gameObject).GetComponent<NetworkObject>();

        // Clone uses the exact same `GlobalObjectIdHash` with the original `NetworkObject`
        cloneNetworkObject.TempGlobalObjectIdHashOverride = networkObject.GlobalObjectIdHash;
        // Manually call `OnValidate()` to cause `cloneNetworkObject` override its `GlobalObjectIdHash` internally
        cloneNetworkObject.OnValidate();

        // Original `NetworkObject` belongs to server `NetworkManager` instance
        networkObject.NetworkManagerOwner = ServerNetworkManagerInstance;

        // Clone `NetworkObject` belongs to client `NetworkManager` instance
        cloneNetworkObject.NetworkManagerOwner = ClientNetworkManagerInstance;
    }
}
```