### PR TITLE
chore: remove #region blocks to better comply with coding standards

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -385,8 +385,6 @@ namespace MLAPI
         /// </summary>
         public virtual void OnLostOwnership() { }
 
-        #region NetworkVariable
-
         private bool m_VarInit = false;
 
         private readonly List<HashSet<int>> m_ChannelMappedNetworkVariableIndexes = new List<HashSet<int>>();
@@ -998,8 +996,6 @@ namespace MLAPI
                 }
             }
         }
-
-        #endregion
 
         /// <summary>
         /// Gets the local instance of a object with a given NetworkId

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -1154,8 +1154,6 @@ namespace MLAPI
                     return;
                 }
 
-                #region INTERNAL MESSAGE
-
                 switch (messageType)
                 {
                     case NetworkConstants.CONNECTION_REQUEST:
@@ -1311,8 +1309,6 @@ namespace MLAPI
 
                         break;
                 }
-
-                #endregion
 
 #if !UNITY_2020_2_OR_NEWER
                 NetworkProfiler.EndEvent();

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/CustomMessageManager.cs
@@ -23,8 +23,6 @@ namespace MLAPI.Messaging
             m_NetworkManager = networkManager;
         }
 
-        #region Unnamed
-
         /// <summary>
         /// Delegate used for incoming unnamed messages
         /// </summary>
@@ -72,10 +70,6 @@ namespace MLAPI.Messaging
             m_NetworkManager.MessageSender.Send(clientId, NetworkConstants.UNNAMED_MESSAGE, networkChannel, buffer);
             PerformanceDataManager.Increment(ProfilerConstants.UnnamedMessageSent);
         }
-
-        #endregion
-
-        #region Named
 
         /// <summary>
         /// Delegate used to handle named messages
@@ -215,7 +209,5 @@ namespace MLAPI.Messaging
                 PerformanceDataManager.Increment(ProfilerConstants.NamedMessageSent);
             }
         }
-
-        #endregion
     }
 }

--- a/testproject/Assets/ManualTests/Scripts/NetworkPrefabPool.cs
+++ b/testproject/Assets/ManualTests/Scripts/NetworkPrefabPool.cs
@@ -7,7 +7,6 @@ using MLAPI.Spawning;
 
 public class NetworkPrefabPool : NetworkBehaviour
 {
-    #region Inspector Exposed Properties
     [Header("General Settings")]
     public bool AutoSpawnEnable = true;
     public float InitialSpawnDelay;
@@ -15,7 +14,7 @@ public class NetworkPrefabPool : NetworkBehaviour
     public int PoolSize;
     public float ObjectSpeed = 10.0f;
 
-    
+
     [Header("Prefab Instance Handling")]
     [Tooltip("When enabled, this will utilize the NetworkPrefabHandler to register a custom INetworkPrefabInstanceHandler")]
     public bool EnableHandler;
@@ -32,9 +31,7 @@ public class NetworkPrefabPool : NetworkBehaviour
     public SwitchSceneHandler SwitchScene;
     public Slider SpawnSlider;
     public Text SpawnSliderValueText;
-    #endregion
 
-    #region private properties
     private bool m_IsSpawningObjects;
 
     private float m_EntitiesPerFrame;
@@ -44,9 +41,6 @@ public class NetworkPrefabPool : NetworkBehaviour
     private List<GameObject> m_ObjectPool;
 
     private MyCustomPrefabSpawnHandler m_MyCustomPrefabSpawnHandler;
-    #endregion
-
-    #region MonoBehaviour Initialization and Destruction Related Methods
 
     /// <summary>
     /// Called when enabled, if already connected we register any custom prefab spawn handler here
@@ -63,7 +57,7 @@ public class NetworkPrefabPool : NetworkBehaviour
     }
 
     /// <summary>
-    /// Handles registering the custom prefab handler 
+    /// Handles registering the custom prefab handler
     /// </summary>
     private void RegisterCustomPrefabHandler()
     {
@@ -133,8 +127,6 @@ public class NetworkPrefabPool : NetworkBehaviour
 
     }
 
-    #endregion
-
     /// <summary>
     /// Detect when we are switching scenes in order
     /// to assure we stop spawning objects
@@ -177,10 +169,9 @@ public class NetworkPrefabPool : NetworkBehaviour
         }
     }
 
-    #region Object Pool Related Methods
     /// <summary>
     /// Determines which object is going to be spawned and then
-    /// initializes the object pool based on 
+    /// initializes the object pool based on
     /// </summary>
     public void InitializeObjectPool()
     {
@@ -234,12 +225,9 @@ public class NetworkPrefabPool : NetworkBehaviour
         m_ObjectPool.Add(obj);
         return obj;
     }
-    #endregion
-
-    #region Spawn Objects Related Methods
 
     /// <summary>
-    /// Starts the 
+    /// Starts the
     /// </summary>
     private void StartSpawningBoxes()
     {
@@ -324,7 +312,6 @@ public class NetworkPrefabPool : NetworkBehaviour
             }
         }
     }
-    #endregion
 }
 
 


### PR DESCRIPTION
> // |[Comments]
> ...
> // |    - Use of #region is _always_ disallowed.
> ...

as outlined in Unity C# Coding Standards, we should never use `#region` blocks (which I also happily agree on).
currently, we have just a few, let's kill these ⚔️ before they evolve into deadly dragons 🐲 around the codebase.