### PR TITLE
ci: upgrade standards check job's machine size to medium from small

### DIFF
--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -5,7 +5,7 @@ standards_{{ projects.first.name }}:
   agent:
     type: Unity::VM
     image: desktop/logging-testing-linux:stable
-    flavor: b1.small
+    flavor: b1.medium
   commands:
     - dotnet --version
     - $HOME/.dotnet/tools/dotnet-format --version


### PR DESCRIPTION
we ran into out-of-memory crashes during runs a few times, seems like we should upgrade to a little larger machine for this job.