### PR TITLE
fix: NetworkBehaviourILPP to iterate over all types in an AsmDef

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.multiplayer.mlapi/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -54,7 +54,7 @@ namespace MLAPI.Editor.CodeGen
                 if (ImportReferences(mainModule))
                 {
                     // process `NetworkBehaviour` types
-                    mainModule.Types
+                    mainModule.GetTypes()
                         .Where(t => t.IsSubclassOf(CodeGenHelpers.NetworkBehaviour_FullName))
                         .ToList()
                         .ForEach(ProcessNetworkBehaviour);
@@ -583,12 +583,6 @@ namespace MLAPI.Editor.CodeGen
                 instructions.Reverse();
                 instructions.ForEach(instruction => processor.Body.Instructions.Insert(0, instruction));
             }
-
-            // process nested `NetworkBehaviour` types
-            typeDefinition.NestedTypes
-                .Where(t => t.IsSubclassOf(CodeGenHelpers.NetworkBehaviour_FullName))
-                .ToList()
-                .ForEach(ProcessNetworkBehaviour);
         }
 
         private CustomAttribute CheckAndGetRPCAttribute(MethodDefinition methodDefinition)


### PR DESCRIPTION
Previously, `NetworkBehaviourILPP` was considering top-level types in an asmdef's main module and was trying to iterate over nested `NetworkBehaviour` derived types.
However, that approach was leaving further nested `NetworkBehaviour` types in the type hierarchy.
Switching from `ModuleDefinition.Types` to `ModuleDefinition.GetTypes()` API, `NetworkBehaviourILPP` now iterates over ALL types and filters for `NetworkBehaviour` derived types and leaving no one outside from ILPP.