### PR TITLE
fix: Handling empty network prefab entries during NetworkManager.Init

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -407,6 +407,7 @@ namespace MLAPI
                         NetworkLog.LogWarning($"{nameof(NetworkPrefab)} cannot be null ({nameof(NetworkPrefab)} at index: {i})");
                     }
 
+                    // Don't try to name the prefab if it doesn't exist
                     if (NetworkConfig.NetworkPrefabs[i] != null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
                     {
                         // Provide the name of the prefab with issues so the user can more easily find the prefab and fix it

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -407,12 +407,6 @@ namespace MLAPI
                         NetworkLog.LogWarning($"{nameof(NetworkPrefab)} cannot be null ({nameof(NetworkPrefab)} at index: {i})");
                     }
 
-                    // Don't try to name the prefab if it doesn't exist
-                    if (NetworkConfig.NetworkPrefabs[i] != null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
-                    {
-                        // Provide the name of the prefab with issues so the user can more easily find the prefab and fix it
-                        UnityEngine.Debug.LogWarning($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") will be removed and ignored.");
-                    }
                     removeEmptyPrefabs.Add(i);
 
                     continue;

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -407,8 +407,11 @@ namespace MLAPI
                         NetworkLog.LogWarning($"{nameof(NetworkPrefab)} cannot be null ({nameof(NetworkPrefab)} at index: {i})");
                     }
 
-                    // Provide the name of the prefab with issues so the user can more easily find the prefab and fix it
-                    UnityEngine.Debug.LogWarning($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") will be removed and ignored.");
+                    if (NetworkConfig.NetworkPrefabs[i] != null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
+                    {
+                        // Provide the name of the prefab with issues so the user can more easily find the prefab and fix it
+                        UnityEngine.Debug.LogWarning($"{nameof(NetworkPrefab)} (\"{NetworkConfig.NetworkPrefabs[i].Prefab.name}\") will be removed and ignored.");
+                    }
                     removeEmptyPrefabs.Add(i);
 
                     continue;


### PR DESCRIPTION
If a network prefab is null, then it needs to only warn of the null network prefab and add it to the list of network prefabs to remove, but not try to display the non-existent prefab's name (which can cause an assert and break the initialization process).
_This was found while helping with the BossRoom upgrade to MLAPI develop branch._