### PR TITLE
perf: cache the behaviour id in NetworkBehaviour

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -338,6 +338,11 @@ namespace MLAPI
         public ushort NetworkBehaviourId => NetworkObject.GetNetworkBehaviourOrderIndex(this);
 
         /// <summary>
+        /// Internally caches the Id of this behaviour in a NetworkObject. Makes look-up faster
+        /// </summary>
+        internal ushort NetworkBehaviourIdCache = 0;
+
+        /// <summary>
         /// Returns a the NetworkBehaviour with a given BehaviourId for the current NetworkObject
         /// </summary>
         /// <param name="behaviourId">The behaviourId to return</param>

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -586,6 +586,9 @@ namespace MLAPI
                 {
                     return instance.NetworkBehaviourIdCache;
                 }
+
+                // invalid cached id reset
+                instance.NetworkBehaviourIdCache = default;
             }
 
             for (ushort i = 0; i < ChildNetworkBehaviours.Count; i++)

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -579,10 +579,21 @@ namespace MLAPI
 
         internal ushort GetNetworkBehaviourOrderIndex(NetworkBehaviour instance)
         {
+            // read the cached index, and verify it first
+            if (instance.NetworkBehaviourIdCache < ChildNetworkBehaviours.Count)
+            {
+                if (ChildNetworkBehaviours[instance.NetworkBehaviourIdCache] == instance)
+                {
+                    return instance.NetworkBehaviourIdCache;
+                }
+            }
+
             for (ushort i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
                 if (ChildNetworkBehaviours[i] == instance)
                 {
+                    // cache the id, for next query
+                    instance.NetworkBehaviourIdCache = i;
                     return i;
                 }
             }


### PR DESCRIPTION
This PR is a follow-up of performance concerns that came up during the Snapshot System PR.

It caches in NetworkBehaviours the Id they were at, in their NetworkObject. When NetworkBehaviours don't change Id (virtually always) it skips a lookup. Improves performance, or, at the very least, alleviate concerns around performance.

Note that this is not limited to the Snapshot System. The vast majority of calls that will be made faster occur outside the SnapshotSystem