### PR TITLE
ci: enable standards check on UTP too

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -56,18 +56,18 @@ namespace MLAPI
         internal NetworkTickSystem NetworkTickSystem { get; private set; }
 
         internal SnapshotSystem SnapshotSystem { get; private set; }
-        
+
         private NetworkPrefabHandler m_PrefabHandler;
         public NetworkPrefabHandler PrefabHandler
         {
             get
             {
-                if(m_PrefabHandler == null)
+                if (m_PrefabHandler == null)
                 {
                     m_PrefabHandler = new NetworkPrefabHandler();
                 }
                 return m_PrefabHandler;
-            }            
+            }
         }
 
         /// <summary>

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -484,12 +484,12 @@ namespace MLAPI.Spawning
                     // within the NetworkSceneManager.SwitchScene method.
                     SpawnedObjectsList.Remove(sobj);
                     if (NetworkManager.PrefabHandler != null && NetworkManager.PrefabHandler.ContainsHandler(sobj))
-                    {                        
+                    {
                         NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(sobj);
                         OnDestroyObject(sobj.NetworkObjectId, false);
                     }
                     else
-                    {                        
+                    {
                         UnityEngine.Object.Destroy(sobj.gameObject);
                     }
                 }

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/ConnectionApproval.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/ConnectionApproval.cs
@@ -19,7 +19,7 @@ namespace MLAPI.RuntimeTests
         public void Setup()
         {
             // Create, instantiate, and host
-            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out _,NetworkManagerHelper.NetworkManagerOperatingMode.None));
+            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out _, NetworkManagerHelper.NetworkManagerOperatingMode.None));
             m_ValidationToken = Guid.NewGuid();
         }
 
@@ -35,10 +35,10 @@ namespace MLAPI.RuntimeTests
 
             var timeOut = Time.realtimeSinceStartup + 3.0f;
             var timedOut = false;
-            while(!m_IsValidated)
+            while (!m_IsValidated)
             {
                 yield return new WaitForSeconds(0.01f);
-                if(timeOut < Time.realtimeSinceStartup)
+                if (timeOut < Time.realtimeSinceStartup)
                 {
                     timedOut = true;
                 }
@@ -46,13 +46,13 @@ namespace MLAPI.RuntimeTests
 
             //Make sure we didn't time out
             Assert.False(timedOut);
-            Assert.True(m_IsValidated);            
+            Assert.True(m_IsValidated);
         }
 
         private void NetworkManagerObject_ConnectionApprovalCallback(byte[] connectionData, ulong clientId, NetworkManager.ConnectionApprovedDelegate callback)
         {
             var stringGuid = Encoding.UTF8.GetString(connectionData);
-            if(m_ValidationToken.ToString() == stringGuid)
+            if (m_ValidationToken.ToString() == stringGuid)
             {
                 m_IsValidated = true;
             }

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs
@@ -21,7 +21,7 @@ namespace MLAPI.RuntimeTests
         /// </summary>
         [Test]
         public void NetworkConfigInvalidNetworkPrefabTest()
-        {  
+        {
             var testPrefabObjectName = "NetworkPrefabHandlerTestObject";
             Guid baseObjectID = NetworkManagerHelper.AddGameNetworkObject(testPrefabObjectName);
             NetworkObject baseObject = NetworkManagerHelper.InstantiatedNetworkObjects[baseObjectID];
@@ -37,7 +37,7 @@ namespace MLAPI.RuntimeTests
 
             //Add a valid prefab
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.NetworkPrefabs.Add(validNetworkPrefab);
-            var exceptionOccurred = false; 
+            var exceptionOccurred = false;
             try
             {
                 NetworkManagerHelper.NetworkManagerObject.StartHost();
@@ -144,7 +144,7 @@ namespace MLAPI.RuntimeTests
         public void Setup()
         {
             //Create, instantiate, and host
-            NetworkManagerHelper.StartNetworkManager(out _,NetworkManagerHelper.NetworkManagerOperatingMode.None);
+            NetworkManagerHelper.StartNetworkManager(out _, NetworkManagerHelper.NetworkManagerOperatingMode.None);
         }
 
         [TearDown]

--- a/com.unity.multiplayer.transport.utp/Runtime/Utilities.cs
+++ b/com.unity.multiplayer.transport.utp/Runtime/Utilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,10 +11,11 @@ namespace Assets.Scripts.Transport
 {
     public static class Utilities
     {
-        unsafe static byte[] SerializeUnmanagedArray<T>(NativeArray<T> value) where T : unmanaged
+        private static unsafe byte[] SerializeUnmanagedArray<T>(NativeArray<T> value) where T : unmanaged
         {
             var bytes = new byte[UnsafeUtility.SizeOf<T>() * value.Length + sizeof(int)];
-            fixed (byte* ptr = bytes) {
+            fixed (byte* ptr = bytes)
+            {
                 var buf = new UnsafeAppendBuffer(ptr, bytes.Length);
                 buf.Add(value);
             }
@@ -22,9 +23,10 @@ namespace Assets.Scripts.Transport
             return bytes;
         }
 
-        unsafe static NativeArray<T> DeserializeUnmanagedArray<T>(byte[] buffer, Allocator allocator = Allocator.Temp) where T : unmanaged
+        private static unsafe NativeArray<T> DeserializeUnmanagedArray<T>(byte[] buffer, Allocator allocator = Allocator.Temp) where T : unmanaged
         {
-            fixed (byte* ptr = buffer) {
+            fixed (byte* ptr = buffer)
+            {
                 var buf = new UnsafeAppendBuffer.Reader(ptr, buffer.Length);
                 buf.ReadNext<T>(out var array, allocator);
                 return array;
@@ -34,7 +36,8 @@ namespace Assets.Scripts.Transport
         public unsafe static byte[] SerializeUnmanaged<T>(ref T value) where T : unmanaged
         {
             var bytes = new byte[UnsafeUtility.SizeOf<T>()];
-            fixed (byte* ptr = bytes) {
+            fixed (byte* ptr = bytes)
+            {
                 UnsafeUtility.CopyStructureToPtr(ref value, ptr);
             }
 
@@ -43,7 +46,8 @@ namespace Assets.Scripts.Transport
 
         public unsafe static T DeserializeUnmanaged<T>(byte[] buffer) where T : unmanaged
         {
-            fixed (byte* ptr = buffer) {
+            fixed (byte* ptr = buffer)
+            {
                 UnsafeUtility.CopyPtrToStructure<T>(ptr, out var value);
                 return value;
             }

--- a/com.unity.multiplayer.transport.utp/Tests/Editor/BasicUTPTest.cs
+++ b/com.unity.multiplayer.transport.utp/Tests/Editor/BasicUTPTest.cs
@@ -15,7 +15,7 @@ namespace MLAPI.UTP.RuntimeTests
             var o = new GameObject();
             var utpTransport = (UTPTransport)o.AddComponent(typeof(UTPTransport));
             utpTransport.Init();
-            
+
             Assert.True(utpTransport.ServerClientId == 0);
 
             utpTransport.Shutdown();

--- a/standards.py
+++ b/standards.py
@@ -18,7 +18,7 @@ parser.add_argument("--yamato", action="store_true")
 
 parser.add_argument("--tool-path", default="dotnet-format")
 parser.add_argument("--project-path", default="testproject")
-parser.add_argument("--project-glob", default="Unity.Multiplayer.MLAPI*.csproj")
+parser.add_argument("--project-glob", default="Unity.Multiplayer*.csproj")
 
 if len(sys.argv) == 1:
     parser.print_help(sys.stderr)


### PR DESCRIPTION
we are already running `standards --check` over `Unity.Multiplayer.MLAPI*.csproj` projects.
this PR changes search glob to `Unity.Multiplayer*.csproj` and now standard check also includes UTP.
_(I also ran `standards.py --fix` locally too, all these changes are coming from that)_