### PR TITLE
refactor: NetworkBehaviour.NetworkObject no longer throws exception

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -300,9 +300,9 @@ namespace MLAPI
                     m_NetworkObject = GetComponentInParent<NetworkObject>();
                 }
 
-                if (m_NetworkObject == null)
+                if (m_NetworkObject == null && NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                 {
-                    throw new NullReferenceException($"Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");
+                    NetworkLog.LogWarning($"Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");
                 }
 
                 return m_NetworkObject;
@@ -312,18 +312,7 @@ namespace MLAPI
         /// <summary>
         /// Gets whether or not this NetworkBehaviour instance has a NetworkObject owner.
         /// </summary>
-        public bool HasNetworkObject
-        {
-            get
-            {
-                if (m_NetworkObject == null)
-                {
-                    m_NetworkObject = GetComponentInParent<NetworkObject>();
-                }
-
-                return m_NetworkObject != null;
-            }
-        }
+        public bool HasNetworkObject => NetworkObject != null;
 
         private NetworkObject m_NetworkObject = null;
 

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBehaviourTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBehaviourTests.cs
@@ -33,12 +33,7 @@ namespace MLAPI.EditorTests
             var gameObject = new GameObject(nameof(AccessNetworkObjectTest));
             var networkBehaviour = gameObject.AddComponent<EmptyNetworkBehaviour>();
 
-            // TODO: Do we really want to throw here?
-            // Future API change: return null
-            Assert.Throws<NullReferenceException>(() =>
-            {
-                var x = networkBehaviour.NetworkObject;
-            });
+            Assert.That(networkBehaviour.NetworkObject, Is.Null);
 
             var networkObject = gameObject.AddComponent<NetworkObject>();
 
@@ -46,12 +41,7 @@ namespace MLAPI.EditorTests
 
             Object.DestroyImmediate(networkObject);
 
-            // TODO: Do we really want to throw here?
-            // Future API change: return null
-            Assert.Throws<NullReferenceException>(() =>
-            {
-                var x = networkBehaviour.NetworkObject;
-            });
+            Assert.That(networkBehaviour.NetworkObject, Is.Null);
 
             // Cleanup
             Object.DestroyImmediate(gameObject);


### PR DESCRIPTION
`NetworkBehaviour.NetworkObject` property no longer throws an exception:
- `NetworkBehaviour.NetworkObject` property getter logs a network warning and returns `null` instead.
- `NetworkBehaviour.HasNetworkObject` is now relying on `NetworkBehaviour.NetworkObject` directly.
- `NetworkBehaviourTests` are also updated accordingly.