### PR TITLE
test:  verifies that a user can use INetworkSerializable with RPCs

### DIFF
--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -86,7 +86,11 @@ namespace TestProject.RuntimeTests
 
 
             var userSerializableClass = new UserSerializableClass();
-            userSerializableClass.MyByteListValues.Add(64);
+            for(int i = 0; i < 32; i++)
+            {
+                userSerializableClass.MyByteListValues.Add((byte)i);
+            }
+
             userSerializableClass.MyintValue = 1;
             userSerializableClass.MyulongValue = 100;
 
@@ -111,9 +115,13 @@ namespace TestProject.RuntimeTests
             Assert.IsNotNull(m_UserSerializableClass);
             Assert.AreEqual(m_UserSerializableClass.MyintValue, userSerializableClass.MyintValue + 1);
             Assert.AreEqual(m_UserSerializableClass.MyulongValue, userSerializableClass.MyulongValue + 1);
-            Assert.AreEqual(m_UserSerializableClass.MyByteListValues.Count, 2);
-            Assert.AreEqual(m_UserSerializableClass.MyByteListValues[0], 64);
-            Assert.AreEqual(m_UserSerializableClass.MyByteListValues[1], 128);
+            Assert.AreEqual(m_UserSerializableClass.MyByteListValues.Count, 64);
+
+            // Validate the list is being sent in order on both sides.
+            for (int i = 0; i < 32; i++)
+            {
+                Assert.AreEqual(m_UserSerializableClass.MyByteListValues[i], i);
+            }
 
             // End of test
             clients[0].StopClient();
@@ -168,7 +176,16 @@ namespace TestProject.RuntimeTests
         {
             userSerializableClass.MyintValue++;
             userSerializableClass.MyulongValue++;
-            userSerializableClass.MyByteListValues.Add(128);
+
+            for (int i = 0; i < 32; i++)
+            {
+                Assert.AreEqual(userSerializableClass.MyByteListValues[i], i);
+            }
+
+            for (int i = 32; i < 64; i++)
+            {
+                userSerializableClass.MyByteListValues.Add((byte)i);
+            }
             SendClientSerializedDataClientRpc(userSerializableClass);
         }
 

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -12,8 +12,7 @@ using Debug = UnityEngine.Debug;
 namespace TestProject.RuntimeTests
 {
     public class RpcINetworkSerializable
-    {       
-
+    {
         private GameObject m_PlayerPrefab;
 
         private int m_OriginalTargetFrameRate;
@@ -45,7 +44,6 @@ namespace TestProject.RuntimeTests
         {
             m_FinishedTest = false;
             var numClients = 1;
-
             var startTime = Time.realtimeSinceStartup;
 
             // Create Host and (numClients) clients 
@@ -54,8 +52,7 @@ namespace TestProject.RuntimeTests
             // Create a default player GameObject to use
             m_PlayerPrefab = new GameObject("Player");
             var networkObject = m_PlayerPrefab.AddComponent<NetworkObject>();
-            m_PlayerPrefab.AddComponent<TestSerializationComponent>(); 
-
+            m_PlayerPrefab.AddComponent<TestSerializationComponent>();
 
             // Make it a prefab
             MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObject);
@@ -98,9 +95,9 @@ namespace TestProject.RuntimeTests
             // Wait until the test has finished or we time out
             var timeOutPeriod = Time.realtimeSinceStartup + 5;
             var timedOut = false;
-            while(!m_FinishedTest)
+            while (!m_FinishedTest)
             {
-                if(Time.realtimeSinceStartup > timeOutPeriod)
+                if (Time.realtimeSinceStartup > timeOutPeriod)
                 {
                     timedOut = true;
                     break;
@@ -114,7 +111,7 @@ namespace TestProject.RuntimeTests
             Assert.IsNotNull(m_UserSerializableClass);
             Assert.AreEqual(m_UserSerializableClass.MyintValue, userSerializableClass.MyintValue + 1);
             Assert.AreEqual(m_UserSerializableClass.MyulongValue, userSerializableClass.MyulongValue + 1);
-            Assert.AreEqual(m_UserSerializableClass.MyByteListValues.Count,2);
+            Assert.AreEqual(m_UserSerializableClass.MyByteListValues.Count, 2);
             Assert.AreEqual(m_UserSerializableClass.MyByteListValues[0], 64);
             Assert.AreEqual(m_UserSerializableClass.MyByteListValues[1], 128);
 
@@ -153,11 +150,19 @@ namespace TestProject.RuntimeTests
 
         public OnSerializableClassUpdatedDelgateHandler OnSerializableClassUpdated;
 
+        /// <summary>
+        /// Starts the unit test and passes the UserSerializableClass from the client to the server
+        /// </summary>
+        /// <param name="userSerializableClass"></param>
         public void ClientStartTest(UserSerializableClass userSerializableClass)
         {
             SendServerSerializedDataServerRpc(userSerializableClass);
         }
 
+        /// <summary>
+        /// Server receives the UserSerializableClass, modifies it, and sends it back
+        /// </summary>
+        /// <param name="userSerializableClass"></param>
         [ServerRpc(RequireOwnership = false)]
         private void SendServerSerializedDataServerRpc(UserSerializableClass userSerializableClass)
         {
@@ -167,6 +172,10 @@ namespace TestProject.RuntimeTests
             SendClientSerializedDataClientRpc(userSerializableClass);
         }
 
+        /// <summary>
+        /// Client receives the UserSerializableClass and then invokes the OnSerializableClassUpdated (if set)
+        /// </summary>
+        /// <param name="userSerializableClass"></param>
         [ClientRpc]
         private void SendClientSerializedDataClientRpc(UserSerializableClass userSerializableClass)
         {
@@ -177,6 +186,9 @@ namespace TestProject.RuntimeTests
         }
     }
 
+    /// <summary>
+    /// The test version of a custom user-defined class that implements INetworkSerializable 
+    /// </summary>
     public class UserSerializableClass : INetworkSerializable
     {
         public int MyintValue;

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -1,0 +1,208 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using MLAPI;
+using MLAPI.RuntimeTests;
+using MLAPI.Serialization;
+using MLAPI.Messaging;
+using Debug = UnityEngine.Debug;
+
+namespace TestProject.RuntimeTests
+{
+    public class RpcINetworkSerializable
+    {       
+
+        private GameObject m_PlayerPrefab;
+
+        private int m_OriginalTargetFrameRate;
+
+        private UserSerializableClass m_UserSerializableClass;
+
+        private bool m_FinishedTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Just always track the current target frame rate (will be re-applied upon TearDown)
+            m_OriginalTargetFrameRate = Application.targetFrameRate;
+
+            // Since we use frame count as a metric, we need to assure it runs at a "common update rate"
+            // between platforms (i.e. Ubuntu seems to run at much higher FPS when set to -1)
+            if (Application.targetFrameRate < 0 || Application.targetFrameRate > 120)
+            {
+                Application.targetFrameRate = 120;
+            }
+        }
+
+        /// <summary>
+        /// Tests that INetworkSerializable can be used through RPCs by a user
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator NetworkSerializableTest()
+        {
+            m_FinishedTest = false;
+            var numClients = 1;
+
+            var startTime = Time.realtimeSinceStartup;
+
+            // Create Host and (numClients) clients 
+            Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
+
+            // Create a default player GameObject to use
+            m_PlayerPrefab = new GameObject("Player");
+            var networkObject = m_PlayerPrefab.AddComponent<NetworkObject>();
+            m_PlayerPrefab.AddComponent<TestSerializationComponent>(); 
+
+
+            // Make it a prefab
+            MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObject);
+
+            // [Host-Side] Set the player prefab
+            server.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
+
+            foreach (var client in clients)
+            {
+                client.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
+            }
+
+            // Start the instances
+            if (!MultiInstanceHelpers.Start(true, server, clients))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // [Client-Side] Wait for a connection to the server 
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
+
+            // [Host-Side] Check to make sure all clients are connected
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
+
+            // [Client-Side] We only need to get the client side Player's NetworkObject so we can grab that instance of the TestSerializationComponent
+            var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), clients[0], clientClientPlayerResult));
+            var clientSideNetworkBehaviourClass = clientClientPlayerResult.Result.gameObject.GetComponent<TestSerializationComponent>();
+            clientSideNetworkBehaviourClass.OnSerializableClassUpdated = OnClientReceivedUserSerializableClassUpdated;
+
+
+            var userSerializableClass = new UserSerializableClass();
+            userSerializableClass.MyByteListValues.Add(64);
+            userSerializableClass.MyintValue = 1;
+            userSerializableClass.MyulongValue = 100;
+
+            clientSideNetworkBehaviourClass.ClientStartTest(userSerializableClass);
+
+            // Wait until the test has finished or we time out
+            var timeOutPeriod = Time.realtimeSinceStartup + 5;
+            var timedOut = false;
+            while(!m_FinishedTest)
+            {
+                if(Time.realtimeSinceStartup > timeOutPeriod)
+                {
+                    timedOut = true;
+                    break;
+                }
+
+                yield return new WaitForSeconds(0.1f);
+            }
+
+            // Verify the test passed
+            Assert.False(timedOut);
+            Assert.IsNotNull(m_UserSerializableClass);
+            Assert.AreEqual(m_UserSerializableClass.MyintValue, userSerializableClass.MyintValue + 1);
+            Assert.AreEqual(m_UserSerializableClass.MyulongValue, userSerializableClass.MyulongValue + 1);
+            Assert.AreEqual(m_UserSerializableClass.MyByteListValues.Count,2);
+            Assert.AreEqual(m_UserSerializableClass.MyByteListValues[0], 64);
+            Assert.AreEqual(m_UserSerializableClass.MyByteListValues[1], 128);
+
+            // End of test
+            clients[0].StopClient();
+            server.StopHost();
+
+        }
+
+        private void OnClientReceivedUserSerializableClassUpdated(UserSerializableClass userSerializableClass)
+        {
+            m_UserSerializableClass = userSerializableClass;
+            m_FinishedTest = true;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (m_PlayerPrefab != null)
+            {
+                Object.Destroy(m_PlayerPrefab);
+                m_PlayerPrefab = null;
+            }
+
+            // Shutdown and clean up both of our NetworkManager instances
+            MultiInstanceHelpers.Destroy();
+
+            // Set the application's target frame rate back to its original value
+            Application.targetFrameRate = m_OriginalTargetFrameRate;
+        }
+    }
+
+    public class TestSerializationComponent : NetworkBehaviour
+    {
+        public delegate void OnSerializableClassUpdatedDelgateHandler(UserSerializableClass userSerializableClass);
+
+        public OnSerializableClassUpdatedDelgateHandler OnSerializableClassUpdated;
+
+        public void ClientStartTest(UserSerializableClass userSerializableClass)
+        {
+            SendServerSerializedDataServerRpc(userSerializableClass);
+        }
+
+        [ServerRpc(RequireOwnership = false)]
+        private void SendServerSerializedDataServerRpc(UserSerializableClass userSerializableClass)
+        {
+            userSerializableClass.MyintValue++;
+            userSerializableClass.MyulongValue++;
+            userSerializableClass.MyByteListValues.Add(128);
+            SendClientSerializedDataClientRpc(userSerializableClass);
+        }
+
+        [ClientRpc]
+        private void SendClientSerializedDataClientRpc(UserSerializableClass userSerializableClass)
+        {
+            if (OnSerializableClassUpdated != null)
+            {
+                OnSerializableClassUpdated.Invoke(userSerializableClass);
+            }
+        }
+    }
+
+    public class UserSerializableClass : INetworkSerializable
+    {
+        public int MyintValue;
+        public ulong MyulongValue;
+        public List<byte> MyByteListValues;
+
+        public void NetworkSerialize(NetworkSerializer serializer)
+        {
+            if (serializer.IsReading)
+            {
+                MyintValue = serializer.Reader.ReadInt32Packed();
+                MyulongValue = serializer.Reader.ReadUInt64Packed();
+                MyByteListValues = new List<byte>(serializer.Reader.ReadByteArray());
+            }
+            else
+            {
+                serializer.Writer.WriteInt32Packed(MyintValue);
+                serializer.Writer.WriteUInt64Packed(MyulongValue);
+                serializer.Writer.WriteByteArray(MyByteListValues.ToArray());
+            }
+        }
+
+        public UserSerializableClass()
+        {
+            MyByteListValues = new List<byte>();
+        }
+    }
+}
+

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -203,7 +203,8 @@ namespace TestProject.RuntimeTests
             for (int i = 0; i < 32; i++)
             {
                 var userSerializableClass = new UserSerializableClass();
-                userSerializableClass.MyintValue = i;                   //Used for testing order of the array
+                //Used for testing order of the array
+                userSerializableClass.MyintValue = i;  
                 m_UserSerializableClassArray.Add(userSerializableClass);
             }
 

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -87,7 +87,7 @@ namespace TestProject.RuntimeTests
 
 
             var userSerializableClass = new UserSerializableClass();
-            for(int i = 0; i < 32; i++)
+            for (int i = 0; i < 32; i++)
             {
                 userSerializableClass.MyByteListValues.Add((byte)i);
             }
@@ -130,15 +130,20 @@ namespace TestProject.RuntimeTests
 
         }
 
+        /// <summary>
+        /// Delegate handler invoked towards the end of the when the NetworkSerializableTest
+        /// </summary>
+        /// <param name="userSerializableClass"></param>
         private void OnClientReceivedUserSerializableClassUpdated(UserSerializableClass userSerializableClass)
         {
             m_UserSerializableClass = userSerializableClass;
             m_FinishedTest = true;
         }
 
-
         /// <summary>
-        /// Tests that INetworkSerializable can be used through RPCs by a user
+        /// Tests that an array of the same type of class that implements the
+        /// INetworkSerializable interface will be received in the same order
+        /// that it was sent.
         /// </summary>
         /// <returns></returns>
         [UnityTest]
@@ -197,7 +202,7 @@ namespace TestProject.RuntimeTests
             // Create an array of userSerializableClass instances 
             for (int i = 0; i < 32; i++)
             {
-                var userSerializableClass = new UserSerializableClass();                
+                var userSerializableClass = new UserSerializableClass();
                 userSerializableClass.MyintValue = i;                   //Used for testing order of the array
                 m_UserSerializableClassArray.Add(userSerializableClass);
             }
@@ -227,7 +232,11 @@ namespace TestProject.RuntimeTests
 
         }
 
-        // Verifies the array maintained its order
+        /// <summary>
+        /// Verifies that the UserSerializableClass array is in the same order
+        /// that it was sent.
+        /// </summary>
+        /// <param name="userSerializableClass"></param>
         private void ValidateUserSerializableClasses(UserSerializableClass[] userSerializableClass)
         {
             var indexCount = 0;
@@ -239,17 +248,26 @@ namespace TestProject.RuntimeTests
             }
         }
 
+        /// <summary>
+        /// Delegate handler invoked when the server sends the client
+        /// the UserSerializableClass array during the NetworkSerializableArrayTest
+        /// </summary>
+        /// <param name="userSerializableClass"></param>
         private void OnClientReceivedUserSerializableClassesUpdated(UserSerializableClass[] userSerializableClass)
         {
             ValidateUserSerializableClasses(userSerializableClass);
             m_FinishedTest = true;
         }
 
+        /// <summary>
+        /// Delegate handler invoked when the client sends the server
+        /// the UserSerializableClass array during the NetworkSerializableArrayTest
+        /// </summary>
+        /// <param name="userSerializableClass"></param>
         private void OnServerReceivedUserSerializableClassesUpdated(UserSerializableClass[] userSerializableClass)
         {
             ValidateUserSerializableClasses(userSerializableClass);
         }
-
 
         [TearDown]
         public void TearDown()
@@ -268,6 +286,10 @@ namespace TestProject.RuntimeTests
         }
     }
 
+    /// <summary>
+    /// Component used with NetworkSerializableTest that houses the
+    /// client and server RPC calls.
+    /// </summary>
     public class TestSerializationComponent : NetworkBehaviour
     {
         public delegate void OnSerializableClassUpdatedDelgateHandler(UserSerializableClass userSerializableClass);
@@ -319,6 +341,12 @@ namespace TestProject.RuntimeTests
         }
     }
 
+    /// <summary>
+    /// Component used with NetworkSerializableArrayTest that
+    /// houses the client and server RPC calls that pass an
+    /// array of UserSerializableClass between the client and
+    /// the server.
+    /// </summary>
     public class TestCustomTypesArrayComponent : NetworkBehaviour
     {
         public delegate void OnSerializableClassesUpdatedDelgateHandler(UserSerializableClass[] userSerializableClasses);
@@ -327,7 +355,8 @@ namespace TestProject.RuntimeTests
         public OnSerializableClassesUpdatedDelgateHandler OnSerializableClassesUpdatedClientRpc;
 
         /// <summary>
-        /// Starts the unit test and passes the userSerializableClasses array from the client to the server
+        /// Starts the unit test and passes the userSerializableClasses array
+        /// from the client to the server
         /// </summary>
         /// <param name="userSerializableClass"></param>
         public void ClientStartTest(UserSerializableClass[] userSerializableClasses)
@@ -336,13 +365,14 @@ namespace TestProject.RuntimeTests
         }
 
         /// <summary>
-        /// Server receives the UserSerializableClasses array, invokes the callback that checks the order, and then passes it back to the client
+        /// Server receives the UserSerializableClasses array, invokes the callback
+        /// that checks the order, and then passes it back to the client
         /// </summary>
         /// <param name="userSerializableClass"></param>
         [ServerRpc(RequireOwnership = false)]
         private void SendServerSerializedDataServerRpc(UserSerializableClass[] userSerializableClasses)
         {
-            if(OnSerializableClassesUpdatedServerRpc != null)
+            if (OnSerializableClassesUpdatedServerRpc != null)
             {
                 OnSerializableClassesUpdatedServerRpc.Invoke(userSerializableClasses);
             }
@@ -350,7 +380,8 @@ namespace TestProject.RuntimeTests
         }
 
         /// <summary>
-        /// Client receives the UserSerializableClasses array and invokes the callback for verification and signaling the test is complete.
+        /// Client receives the UserSerializableClasses array and invokes the callback
+        /// for verification and signaling the test is complete.
         /// </summary>
         /// <param name="userSerializableClass"></param>
         [ClientRpc]

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -185,13 +185,13 @@ namespace TestProject.RuntimeTests
             // [Host-Side] Check to make sure all clients are connected
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
 
-            // [Host-Side] Get the host-server side Player's NetworkObject so we can grab that instance of the TestSerializationComponent
+            // [Host-Side] Get the host-server side Player's NetworkObject so we can grab that instance of the TestCustomTypesArrayComponent
             var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), server, serverClientPlayerResult));
             var serverSideNetworkBehaviourClass = serverClientPlayerResult.Result.gameObject.GetComponent<TestCustomTypesArrayComponent>();
             serverSideNetworkBehaviourClass.OnSerializableClassesUpdatedServerRpc = OnServerReceivedUserSerializableClassesUpdated;
 
-            // [Client-Side] Get the client side Player's NetworkObject so we can grab that instance of the TestSerializationComponent
+            // [Client-Side] Get the client side Player's NetworkObject so we can grab that instance of the TestCustomTypesArrayComponent
             var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), clients[0], clientClientPlayerResult));
             var clientSideNetworkBehaviourClass = clientClientPlayerResult.Result.gameObject.GetComponent<TestCustomTypesArrayComponent>();

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -197,8 +197,7 @@ namespace TestProject.RuntimeTests
             // Create an array of userSerializableClass instances 
             for (int i = 0; i < 32; i++)
             {
-                var userSerializableClass = new UserSerializableClass();
-                userSerializableClass.MyByteListValues.Add(128);
+                var userSerializableClass = new UserSerializableClass();                
                 userSerializableClass.MyintValue = i;                   //Used for testing order of the array
                 m_UserSerializableClassArray.Add(userSerializableClass);
             }
@@ -228,31 +227,30 @@ namespace TestProject.RuntimeTests
 
         }
 
-        private void OnClientReceivedUserSerializableClassesUpdated(UserSerializableClass[] userSerializableClass)
+        // Verifies the array maintained its order
+        private void ValidateUserSerializableClasses(UserSerializableClass[] userSerializableClass)
         {
             var indexCount = 0;
             // Check the order of the array
             foreach (var customTypeEntry in userSerializableClass)
             {
                 Assert.AreEqual(customTypeEntry.MyintValue, indexCount);
-                Assert.AreEqual(customTypeEntry.MyByteListValues[0], 128);
                 indexCount++;
             }
+        }
+
+        private void OnClientReceivedUserSerializableClassesUpdated(UserSerializableClass[] userSerializableClass)
+        {
+            ValidateUserSerializableClasses(userSerializableClass);
             m_FinishedTest = true;
         }
 
         private void OnServerReceivedUserSerializableClassesUpdated(UserSerializableClass[] userSerializableClass)
         {
-            var indexCount = 0;
-            // Check the order of the array
-            foreach (var customTypeEntry in userSerializableClass)
-            {
-                Assert.AreEqual(customTypeEntry.MyintValue, indexCount);
-                Assert.AreEqual(customTypeEntry.MyByteListValues[0], 128);
-                indexCount++;
-            }
+            ValidateUserSerializableClasses(userSerializableClass);
         }
-        
+
+
         [TearDown]
         public void TearDown()
         {
@@ -329,7 +327,7 @@ namespace TestProject.RuntimeTests
         public OnSerializableClassesUpdatedDelgateHandler OnSerializableClassesUpdatedClientRpc;
 
         /// <summary>
-        /// Starts the unit test and passes the UserSerializableClass from the client to the server
+        /// Starts the unit test and passes the userSerializableClasses array from the client to the server
         /// </summary>
         /// <param name="userSerializableClass"></param>
         public void ClientStartTest(UserSerializableClass[] userSerializableClasses)
@@ -338,7 +336,7 @@ namespace TestProject.RuntimeTests
         }
 
         /// <summary>
-        /// Server receives the UserSerializableClass, modifies it, and sends it back
+        /// Server receives the UserSerializableClasses array, invokes the callback that checks the order, and then passes it back to the client
         /// </summary>
         /// <param name="userSerializableClass"></param>
         [ServerRpc(RequireOwnership = false)]
@@ -352,7 +350,7 @@ namespace TestProject.RuntimeTests
         }
 
         /// <summary>
-        /// Client receives the UserSerializableClass and then invokes the OnSerializableClassUpdated (if set)
+        /// Client receives the UserSerializableClasses array and invokes the callback for verification and signaling the test is complete.
         /// </summary>
         /// <param name="userSerializableClass"></param>
         [ClientRpc]

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs.meta
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acbf87fda7c6c41449409c6470481a95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Summary**
This task is to verify the user can define their own custom network serialized type.
This task is based on the following user stories:
[ MTT-787](https://jira.unity3d.com/browse/MTT-787)
[ MTT-788](https://jira.unity3d.com/browse/MTT-788)


**Acceptance Criteria**
A user should be able to implement the INetworkSerializable interface within a class and use that class as an RPC Parameter to pass between both client and server RPCs.  The test should include the reading and writing of custom values within the custom INetworkSerializable based class.

A user should be able to send arrays of the same class type that implements the INetworkSerializable interface and expect the array to maintain the exact same order from when it was sent to when it is received.

**Acceptance Tests**
From TestRunner:
TestProject->RuntimeTests->RpcINetworkSerializable->NetworkSerializableTest
TestProject->RuntimeTests->RpcINetworkSerializable->NetworkSerializableArrayTest