### PR TITLE
test: verify that empty or null arrays of custom INetworkSerializable types can be sent and received

### DIFF
--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -23,6 +23,7 @@ namespace TestProject.RuntimeTests
         private bool m_FinishedTest;
 
         private bool m_IsSendingNull;
+        private bool m_IsArrayEmpty;
 
         [SetUp]
         public void SetUp()
@@ -186,6 +187,13 @@ namespace TestProject.RuntimeTests
         {
             m_IsSendingNull = sendNullArray;
             m_FinishedTest = false;
+            m_IsArrayEmpty = false;
+
+            if (arraySize == 0)
+            {
+                m_IsArrayEmpty = true;
+            }
+
             var numClients = 1;
             var startTime = Time.realtimeSinceStartup;
 
@@ -238,7 +246,7 @@ namespace TestProject.RuntimeTests
             if (!m_IsSendingNull)
             {
                 // Create an array of userSerializableClass instances 
-                for (int i = 0; i < 32; i++)
+                for (int i = 0; i < arraySize; i++)
                 {
                     var userSerializableClass = new UserSerializableClass();
                     //Used for testing order of the array
@@ -286,6 +294,10 @@ namespace TestProject.RuntimeTests
             if (m_IsSendingNull)
             {
                 Assert.IsNull(userSerializableClass);
+            }
+            else if (m_IsArrayEmpty)
+            {
+                Assert.AreEqual(userSerializableClass.Length,0);
             }
             else
             {


### PR DESCRIPTION
**Summary**
This task is associated with [MTT-789]( https://jira.unity3d.com/browse/MTT-789)
This task is to convert the below Test Rail manual tests over to automated tests.
T2910451: Verify empty arrays of custom types are being serialized
T2910452: Verify null arrays of custom types are being serialized

**Acceptance Criteria**
Users should be able to send empty or null arrays for custom INetworkSerializable types. When an empty or null array is sent, the receiver should be able to receive the empty or null array.

**Acceptance Tests**
From Test Runner:
TestProject->RuntimeTests->RpcINetworkSerializable->NetworkSerializableEmptyArrayTest
TestProject->RuntimeTests->RpcINetworkSerializable->NetworkSerializableNULLArrayTest