### PR TITLE
refactor!: tick param removal

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -654,10 +654,6 @@ namespace MLAPI
                                 {
                                     writtenAny = true;
 
-                                    // write the network tick at which this NetworkVariable was modified remotely
-                                    // this will allow lag-compensation
-                                    writer.WriteUInt16Packed(NetworkVariableFields[k].RemoteTick);
-
                                     if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                                     {
                                         using (var varBuffer = PooledNetworkBuffer.Get())
@@ -711,9 +707,6 @@ namespace MLAPI
         {
             using (var reader = PooledNetworkReader.Get(stream))
             {
-                // read the remote network tick at which this variable was written.
-                ushort remoteTick = reader.ReadUInt16Packed();
-
                 for (int i = 0; i < networkVariableList.Count; i++)
                 {
                     ushort varSize = 0;
@@ -772,7 +765,7 @@ namespace MLAPI
 
                     long readStartPos = stream.Position;
 
-                    networkVariableList[i].ReadDelta(stream, networkManager.IsServer, localTick, remoteTick);
+                    networkVariableList[i].ReadDelta(stream, networkManager.IsServer);
                     PerformanceDataManager.Increment(ProfilerConstants.NetworkVarDeltas);
 
                     ProfilerStatManager.NetworkVarsRcvd.Record();
@@ -859,7 +852,7 @@ namespace MLAPI
 
                     long readStartPos = stream.Position;
 
-                    networkVariableList[i].ReadField(stream, NetworkTickSystem.NoTick, NetworkTickSystem.NoTick);
+                    networkVariableList[i].ReadField(stream);
                     PerformanceDataManager.Increment(ProfilerConstants.NetworkVarUpdates);
 
                     ProfilerStatManager.NetworkVarsRcvd.Record();
@@ -974,7 +967,7 @@ namespace MLAPI
 
                     long readStartPos = stream.Position;
 
-                    networkVariableList[j].ReadField(stream, NetworkTickSystem.NoTick, NetworkTickSystem.NoTick);
+                    networkVariableList[j].ReadField(stream);
 
                     if (networkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                     {

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -607,10 +607,6 @@ namespace MLAPI
                             writer.WriteUInt64Packed(NetworkObjectId);
                             writer.WriteUInt16Packed(NetworkObject.GetNetworkBehaviourOrderIndex(this));
 
-                            // Write the current tick frame
-                            // todo: this is currently done per channel, per tick. The snapshot system might improve on this
-                            writer.WriteUInt16Packed(CurrentTick);
-
                             bool writtenAny = false;
                             for (int k = 0; k < NetworkVariableFields.Count; k++)
                             {
@@ -758,10 +754,6 @@ namespace MLAPI
 
                         return;
                     }
-
-                    // read the local network tick at which this variable was written.
-                    // if this var was updated from our machine, this local tick will be locally valid
-                    ushort localTick = reader.ReadUInt16Packed();
 
                     long readStartPos = stream.Position;
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
@@ -317,8 +317,7 @@ namespace MLAPI
 
                     // todo --M1--
                     // Review whether tick still belong in netvar or in the snapshot table.
-                    nv.ReadDelta(m_ReceivedSnapshot.Stream, m_NetworkManager.IsServer,
-                        m_NetworkManager.NetworkTickSystem.GetTick(), m_ReceivedSnapshot.Entries[i].TickWritten);
+                    nv.ReadDelta(m_ReceivedSnapshot.Stream, m_NetworkManager.IsServer);
                 }
 
                 m_ReceivedSnapshot.Entries[i].Fresh = false;

--- a/com.unity.multiplayer.mlapi/Runtime/NetworkVariable/Collections/NetworkDictionary.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/NetworkVariable/Collections/NetworkDictionary.cs
@@ -88,7 +88,7 @@ namespace MLAPI.NetworkVariable.Collections
         }
 
         /// <inheritdoc />
-        public void ReadDelta(Stream stream, bool keepDirtyDelta, ushort localTick, ushort remoteTick)
+        public void ReadDelta(Stream stream, bool keepDirtyDelta)
         {
             using (var reader = PooledNetworkReader.Get(stream))
             {
@@ -236,7 +236,7 @@ namespace MLAPI.NetworkVariable.Collections
         }
 
         /// <inheritdoc />
-        public void ReadField(Stream stream, ushort localTick, ushort remoteTick)
+        public void ReadField(Stream stream)
         {
             using (var reader = PooledNetworkReader.Get(stream))
             {

--- a/com.unity.multiplayer.mlapi/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -223,7 +223,7 @@ namespace MLAPI.NetworkVariable.Collections
         }
 
         /// <inheritdoc />
-        public void ReadField(Stream stream, ushort localTick, ushort remoteTick)
+        public void ReadField(Stream stream)
         {
             using (var reader = PooledNetworkReader.Get(stream))
             {
@@ -237,7 +237,7 @@ namespace MLAPI.NetworkVariable.Collections
         }
 
         /// <inheritdoc />
-        public void ReadDelta(Stream stream, bool keepDirtyDelta, ushort localTick, ushort remoteTick)
+        public void ReadDelta(Stream stream, bool keepDirtyDelta)
         {
             using (var reader = PooledNetworkReader.Get(stream))
             {

--- a/com.unity.multiplayer.mlapi/Runtime/NetworkVariable/Collections/NetworkSet.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/NetworkVariable/Collections/NetworkSet.cs
@@ -209,7 +209,7 @@ namespace MLAPI.NetworkVariable.Collections
         }
 
         /// <inheritdoc />
-        public void ReadField(Stream stream, ushort localTick, ushort remoteTick)
+        public void ReadField(Stream stream)
         {
             using (var reader = PooledNetworkReader.Get(stream))
             {
@@ -224,7 +224,7 @@ namespace MLAPI.NetworkVariable.Collections
         }
 
         /// <inheritdoc />
-        public void ReadDelta(Stream stream, bool keepDirtyDelta, ushort localTick, ushort remoteTick)
+        public void ReadDelta(Stream stream, bool keepDirtyDelta)
         {
             using (var reader = PooledNetworkReader.Get(stream))
             {

--- a/com.unity.multiplayer.mlapi/Runtime/NetworkVariable/INetworkVariable.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/NetworkVariable/INetworkVariable.cs
@@ -57,7 +57,7 @@ namespace MLAPI.NetworkVariable
         /// <param name="stream">The stream to read the state from</param>
         /// <param name="localTick">The local network tick at which this var was written, on the machine it was written </param>
         /// <param name="remoteTick">The remote network tick at which this var was sent by the host </param>
-        void ReadField(Stream stream, ushort localTick, ushort remoteTick);
+        void ReadField(Stream stream);
 
         /// <summary>
         /// Reads delta from the reader and applies them to the internal value
@@ -66,7 +66,7 @@ namespace MLAPI.NetworkVariable
         /// <param name="keepDirtyDelta">Whether or not the delta should be kept as dirty or consumed</param>
         /// <param name="localTick">The local network tick at which this var was written, on the machine it was written </param>
         /// <param name="remoteTick">The remote network tick at which this var was sent by the host </param>
-        void ReadDelta(Stream stream, bool keepDirtyDelta, ushort localTick, ushort remoteTick);
+        void ReadDelta(Stream stream, bool keepDirtyDelta);
 
         /// <summary>
         /// Sets NetworkBehaviour the container belongs to.
@@ -74,9 +74,5 @@ namespace MLAPI.NetworkVariable
         /// <param name="behaviour">The behaviour the container behaves to</param>
         void SetNetworkBehaviour(NetworkBehaviour behaviour);
 
-        /// <summary>
-        /// Accessor for the RemoteTick stored in the networkVariable, list, set or dictionary
-        /// </summary>
-        ushort RemoteTick { get; }
     }
 }

--- a/testproject/Assets/Tests/Manual/Scripts/ManualNetworkVariableTest.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ManualNetworkVariableTest.cs
@@ -106,34 +106,40 @@ namespace TestProject.ManualTests
             {
                 // compute the delta in tick between client and server,
                 // as seen from the client, when it receives a value not from itself
-                if (m_TestVar.LocalTick != NetworkTickSystem.NoTick)
-                {
-                    int delta = m_TestVar.LocalTick - m_TestVar.RemoteTick;
-                    m_Count++;
 
-                    if (!m_Valid)
-                    {
-                        m_Valid = true;
-                        m_MinDelta = delta;
-                        m_MaxDelta = delta;
-                        m_LastRemoteTick = m_TestVar.RemoteTick;
-                    }
-                    else
-                    {
-                        m_MinDelta = Math.Min(delta, m_MinDelta);
-                        m_MaxDelta = Math.Max(delta, m_MaxDelta);
-
-                        // tick should not go backward until wrap around (which should be a long time)
-                        if (m_TestVar.RemoteTick == m_LastRemoteTick)
-                        {
-                            m_Problems += "Same remote tick receive twice\n";
-                        }
-                        else if (m_TestVar.RemoteTick < m_LastRemoteTick)
-                        {
-                            m_Problems += "Ticks went backward\n";
-                        }
-                    }
-                }
+               // MSW: This test relies on the LocalTick variable which was otherwise dormant
+               //  and remove from MLAPI.  
+               //
+               //  I'm assuming This test will be superseded by the snapshot variable sync
+               //
+//                if (m_TestVar.LocalTick != NetworkTickSystem.NoTick)
+//                {
+//                    int delta = m_TestVar.LocalTick - m_TestVar.RemoteTick;
+//                    m_Count++;
+//
+//                    if (!m_Valid)
+//                    {
+//                        m_Valid = true;
+//                        m_MinDelta = delta;
+//                        m_MaxDelta = delta;
+//                        m_LastRemoteTick = m_TestVar.RemoteTick;
+//                    }
+//                    else
+//                    {
+//                        m_MinDelta = Math.Min(delta, m_MinDelta);
+//                        m_MaxDelta = Math.Max(delta, m_MaxDelta);
+//
+//                        // tick should not go backward until wrap around (which should be a long time)
+//                        if (m_TestVar.RemoteTick == m_LastRemoteTick)
+//                        {
+//                            m_Problems += "Same remote tick receive twice\n";
+//                        }
+//                        else if (m_TestVar.RemoteTick < m_LastRemoteTick)
+//                        {
+//                            m_Problems += "Ticks went backward\n";
+//                        }
+//                    }
+//                }
             }
 
             if (m_Count == k_EndIterations)

--- a/testproject/Assets/Tests/Manual/Scripts/ManualNetworkVariableTest.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ManualNetworkVariableTest.cs
@@ -112,6 +112,7 @@ namespace TestProject.ManualTests
                //
                //  I'm assuming This test will be superseded by the snapshot variable sync
                //
+
 //                if (m_TestVar.LocalTick != NetworkTickSystem.NoTick)
 //                {
 //                    int delta = m_TestVar.LocalTick - m_TestVar.RemoteTick;


### PR DESCRIPTION
see https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/pull/845

Looks like the tick parameters are ignored in all impl's of ReadField() (e.g. NetworkDictionary, NetworkList, NetworkSet) with the only exception being that NetworkVariable forwards it to its LocalTick & RemoteTick variables.

LocalTick itself is never used except in ManualNetworkVariableTest.cs, which we could re-write.

RemoteTick is written to the network in NetworkBehaviour::NetworkVariableUpdate with the comment "this will allow lag-compensation".

Finally, this gets read in at NetworkBehaviour::HandleNetworkVariableDeltas, and shoved back down ReadDelta, where it is never actually used.

I sure could be missing something, but I think this may all be no op code and we can delete these parameters.

Plus all this lag comp kinda thing's going to move, yes?